### PR TITLE
feat: support CSF 1.0-style story name

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To maximize compatibility, avoid using complex expressions and importing from ot
 
 ### CSF and MDX only
 
-Only [Component Story Format](https://storybook.js.org/docs/react/api/csf) (CSF, using [hoisted CSF annotations](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#hoisted-csf-annotations)) and [MDX](https://storybook.js.org/docs/react/api/mdx) stories are supported.
+Only [Component Story Format](https://storybook.js.org/docs/react/api/csf) (CSF, using CSF 1.0 or [2.0 with hoisted CSF annotations](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#hoisted-csf-annotations)) and [MDX](https://storybook.js.org/docs/react/api/mdx) stories are supported.
 
 The legacy `storiesOf` API is not supported.
 

--- a/src/parser/__snapshots__/parseStoriesFile.test.ts.snap
+++ b/src/parser/__snapshots__/parseStoriesFile.test.ts.snap
@@ -200,6 +200,90 @@ Object {
 }
 `;
 
+exports[`parseStoriesFile parses story file project/src/stories/CsfV1.stories.js 1`] = `
+Object {
+  "meta": Object {
+    "id": undefined,
+    "location": Object {
+      "end": Object {
+        "column": 1,
+        "line": 3,
+      },
+      "start": Object {
+        "column": 15,
+        "line": 1,
+      },
+    },
+    "title": "Example/CSF v1",
+  },
+  "stories": Array [
+    Object {
+      "exportName": "V1StoryName",
+      "id": "example-csf-v1--v-1-story-name",
+      "location": Object {
+        "end": Position {
+          "column": 24,
+          "line": 5,
+        },
+        "start": Position {
+          "column": 13,
+          "line": 5,
+        },
+      },
+      "name": "Renamed via non-hoisted story",
+      "properties": Object {
+        "story": Object {
+          "name": "Renamed via non-hoisted story",
+        },
+      },
+    },
+    Object {
+      "exportName": "V2V1StoryName",
+      "id": "example-csf-v1--v-2-v-1-story-name",
+      "location": Object {
+        "end": Position {
+          "column": 26,
+          "line": 11,
+        },
+        "start": Position {
+          "column": 13,
+          "line": 11,
+        },
+      },
+      "name": "v2 name override",
+      "properties": Object {
+        "story": Object {
+          "name": "v1 name should be overridden",
+        },
+        "storyName": "v2 name override",
+      },
+    },
+    Object {
+      "exportName": "V2V1StoryNameEmpty",
+      "id": "example-csf-v1--v-2-v-1-story-name-empty",
+      "location": Object {
+        "end": Position {
+          "column": 31,
+          "line": 18,
+        },
+        "start": Position {
+          "column": 13,
+          "line": 18,
+        },
+      },
+      "name": "V 2 V 1 Story Name Empty",
+      "properties": Object {
+        "story": Object {
+          "name": "v1 name should be ignored",
+        },
+        "storyName": "",
+      },
+    },
+  ],
+  "type": "csf",
+}
+`;
+
 exports[`parseStoriesFile parses story file project/src/stories/CsfWithMdx.stories.js 1`] = `
 Object {
   "meta": Object {

--- a/src/parser/csf/__snapshots__/csf.test.ts.snap
+++ b/src/parser/csf/__snapshots__/csf.test.ts.snap
@@ -99,6 +99,84 @@ Object {
 }
 `;
 
+exports[`csf parses story file project/src/stories/CsfV1.stories.js 1`] = `
+Object {
+  "meta": Object {
+    "location": Object {
+      "end": Object {
+        "column": 1,
+        "line": 3,
+      },
+      "start": Object {
+        "column": 15,
+        "line": 1,
+      },
+    },
+    "properties": Object {
+      "title": "Example/CSF v1",
+    },
+  },
+  "stories": Array [
+    Object {
+      "exportName": "V1StoryName",
+      "location": Object {
+        "end": Position {
+          "column": 24,
+          "line": 5,
+        },
+        "start": Position {
+          "column": 13,
+          "line": 5,
+        },
+      },
+      "properties": Object {
+        "story": Object {
+          "name": "Renamed via non-hoisted story",
+        },
+      },
+    },
+    Object {
+      "exportName": "V2V1StoryName",
+      "location": Object {
+        "end": Position {
+          "column": 26,
+          "line": 11,
+        },
+        "start": Position {
+          "column": 13,
+          "line": 11,
+        },
+      },
+      "properties": Object {
+        "story": Object {
+          "name": "v1 name should be overridden",
+        },
+        "storyName": "v2 name override",
+      },
+    },
+    Object {
+      "exportName": "V2V1StoryNameEmpty",
+      "location": Object {
+        "end": Position {
+          "column": 31,
+          "line": 18,
+        },
+        "start": Position {
+          "column": 13,
+          "line": 18,
+        },
+      },
+      "properties": Object {
+        "story": Object {
+          "name": "v1 name should be ignored",
+        },
+        "storyName": "",
+      },
+    },
+  ],
+}
+`;
+
 exports[`csf parses story file project/src/stories/CsfWithMdx.stories.js 1`] = `
 Object {
   "meta": Object {

--- a/src/parser/csf/csf.ts
+++ b/src/parser/csf/csf.ts
@@ -8,11 +8,21 @@ import { logDebug } from '../../log/log';
 import { parseFromContents, RawStory } from './parseFromContents';
 
 const getStoryName = (rawStory: RawStory) => {
-  const rawStoryName = rawStory.properties.storyName;
+  const hoistedStoryName = rawStory.properties.storyName;
 
-  return typeof rawStoryName === 'string' && rawStoryName
-    ? rawStoryName
-    : storyNameFromExport(rawStory.exportName);
+  if (typeof hoistedStoryName === 'string') {
+    return hoistedStoryName || storyNameFromExport(rawStory.exportName);
+  }
+
+  const { story } = rawStory.properties;
+  if (typeof story === 'object' && story && 'name' in story) {
+    const csfV1StoryName: unknown = (story as Record<string, unknown>).name;
+    if (typeof csfV1StoryName === 'string' && csfV1StoryName) {
+      return csfV1StoryName;
+    }
+  }
+
+  return storyNameFromExport(rawStory.exportName);
 };
 
 const parseCsf = (contents: string) => {

--- a/test/project/src/stories/CsfV1.stories.js
+++ b/test/project/src/stories/CsfV1.stories.js
@@ -1,0 +1,23 @@
+export default {
+  title: 'Example/CSF v1',
+};
+
+export const V1StoryName = () =>
+  'CSF v1 renamed story: should be "Renamed via non-hoisted story"';
+V1StoryName.story = {
+  name: 'Renamed via non-hoisted story',
+};
+
+export const V2V1StoryName = () =>
+  'CSF v2 renamed story overrides v1: should be "v2 name override"';
+V2V1StoryName.story = {
+  name: 'v1 name should be overridden',
+};
+V2V1StoryName.storyName = 'v2 name override';
+
+export const V2V1StoryNameEmpty = () =>
+  'Uses generated story name: should be "V 2 V 1 Story Name Empty"';
+V2V1StoryNameEmpty.story = {
+  name: 'v1 name should be ignored',
+};
+V2V1StoryNameEmpty.storyName = '';


### PR DESCRIPTION
Support legacy CSF 1.0 story annotations, i.e., using
`StoryFn.story.name` instead of `StoryFn.storyName`. To match Storybook
behavior, CSF 2.0-style hoisted annotations are preferred if specified,
with 1.0-style used as a fallback.