### PR TITLE
chore: fix jest config type

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -3,10 +3,9 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-/**
+export default /**
  * @type import('@jest/types').Config.InitialOptions
- */
-export default {
+ */ ({
   clearMocks: true,
   coverageDirectory: 'coverage',
   coverageProvider: 'v8',
@@ -23,4 +22,4 @@ export default {
       },
     ],
   },
-};
+});


### PR DESCRIPTION
Adjust the JSDoc in `jest.config.mjs` so that TypeScript properly
recognizes the desired type of the exported config. Although it may not
have worked in the first place, it caused errors when upgrading to
TypeScript 4.5.