### PR TITLE
fix: ignore empty csf v2 storyName

### DIFF
--- a/src/parser/__snapshots__/parseStoriesFile.test.ts.snap
+++ b/src/parser/__snapshots__/parseStoriesFile.test.ts.snap
@@ -390,7 +390,7 @@ Object {
           "line": 18,
         },
       },
-      "name": "V 2 V 1 Story Name Empty",
+      "name": "v1 name should be used",
       "nameForId": "V 2 V 1 Story Name Empty",
     },
   ],

--- a/src/parser/csf/__snapshots__/csf.test.ts.snap
+++ b/src/parser/csf/__snapshots__/csf.test.ts.snap
@@ -278,7 +278,7 @@ Object {
       },
       "properties": Object {
         "story": Object {
-          "name": "v1 name should be ignored",
+          "name": "v1 name should be used",
         },
         "storyName": "",
       },

--- a/src/parser/csf/csf.ts
+++ b/src/parser/csf/csf.ts
@@ -11,8 +11,8 @@ import { parseFromContents, RawStory } from './parseFromContents';
 const getStoryName = (rawStory: RawStory) => {
   const hoistedStoryName = rawStory.properties.storyName;
 
-  if (typeof hoistedStoryName === 'string') {
-    return hoistedStoryName || storyNameFromExport(rawStory.exportName);
+  if (typeof hoistedStoryName === 'string' && hoistedStoryName) {
+    return hoistedStoryName;
   }
 
   const { story } = rawStory.properties;

--- a/src/story/__snapshots__/StoryExplorerStoryFile.test.ts.snap
+++ b/src/story/__snapshots__/StoryExplorerStoryFile.test.ts.snap
@@ -153,7 +153,7 @@ Object {
     Object {
       "id": "example-csf-v1--v-2-v-1-story-name-empty",
       "isDocs": false,
-      "name": "V 2 V 1 Story Name Empty",
+      "name": "v1 name should be used",
     },
   ],
   "title": "Example/CSF v1",

--- a/test/project/src/stories/CsfV1.stories.js
+++ b/test/project/src/stories/CsfV1.stories.js
@@ -16,8 +16,8 @@ V2V1StoryName.story = {
 V2V1StoryName.storyName = 'v2 name override';
 
 export const V2V1StoryNameEmpty = () =>
-  'Uses generated story name: should be "V 2 V 1 Story Name Empty"';
+  'Uses v1 name over empty v2 name: should be "v1 name should be used" (as of Storybook 6.4)';
 V2V1StoryNameEmpty.story = {
-  name: 'v1 name should be ignored',
+  name: 'v1 name should be used',
 };
 V2V1StoryNameEmpty.storyName = '';


### PR DESCRIPTION
Prior to Storybook 6.4, a story with an empty string as a CSF v2-style
hoisted `storyName` and a (non-empty) CSF v1-style `story.name` would
have a display name generated from the export name, as if there were no
given story name at all. Starting with 6.4, the behavior has changed so
that the v2-style empty string name is disregarded and the v1-style name
is used instead.

Although this change would technically result in a different display
name between this extension and older versions of Storybook, this
scenario is fairly contrived and unlikely to appear in the real world.
So it doesn't appear to be worth adding any kind of version detection or
fallback behavior to replicate Storybook's exact behavior in this case.