### PR TITLE
fix: warn when config file parsing fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -384,13 +384,13 @@
     "viewsWelcome": [
       {
         "view": "storyExplorer.storiesView",
-        "contents": "No Storybook configuration could be loaded. Add a Storybook configuration to your project if it doesn't exist, or [set the Storybook configuration path](command:storyExplorer.openStorybookConfigDirSetting) to your existing configuration to see your project's stories here.",
-        "when": "!storyExplorer.storybookConfigDetected"
+        "contents": "There was a problem parsing your Storybook configuration. [Check your Storybook configuration](command:storyExplorer.openStorybookConfig), or [try manually specifying your project's stories](command:storyExplorer.openStoriesGlobsSetting).",
+        "when": "storyExplorer.storybookConfigDetected && !storyExplorer.storybookConfigParsed"
       },
       {
         "view": "storyExplorer.storiesView",
         "contents": "No stories were found. Add a story to see it appear here, or [check your Storybook configuration](command:storyExplorer.openStorybookConfig).",
-        "when": "storyExplorer.storybookConfigDetected"
+        "when": "storyExplorer.storybookConfigParsed"
       }
     ]
   },

--- a/src/commands/openStoriesGlobsSetting.ts
+++ b/src/commands/openStoriesGlobsSetting.ts
@@ -1,10 +1,10 @@
-import { storybookConfigDirConfig } from '../constants/constants';
+import { storiesGlobsConfig } from '../constants/constants';
 import { logError } from '../log/log';
 import { openWorkspaceSetting } from '../util/openWorkspaceSetting';
 
-export const openStorybookConfigDirSetting = () => async () => {
+export const openStoriesGlobsSetting = () => async () => {
   try {
-    await openWorkspaceSetting(storybookConfigDirConfig);
+    await openWorkspaceSetting(storiesGlobsConfig);
   } catch (e) {
     logError('Failed to open Storybook URL workspace setting', e);
   }

--- a/src/config/StoriesGlobsDetectProvider.ts
+++ b/src/config/StoriesGlobsDetectProvider.ts
@@ -1,22 +1,35 @@
 import { Disposable, EventEmitter } from 'vscode';
+import { storybookConfigParsedContext } from '../constants/constants';
 import { logWarn } from '../log/log';
 
 import { getStoriesGlobs } from '../storybook/getStoriesGlobs';
 import { parseConfigFile } from '../storybook/parseConfig';
 import { FileWatcher } from '../util/FileWatcher';
+import { setContext } from '../util/setContext';
 import type { Aggregator } from './Aggregator';
 import type { ConfigProvider } from './ConfigProvider';
 import type { GlobSpecifier } from './GlobSpecifier';
 import type { StorybookConfigLocation } from './StorybookConfigLocation';
 import { interpretStoriesConfigItem } from './normalizeStoriesEntry';
 
+const setParsedConfigContext = (parsed: boolean) => {
+  setContext(storybookConfigParsedContext, parsed);
+};
+
 const getStoriesGlobsFromFileUri = async (
   location: StorybookConfigLocation,
 ): Promise<GlobSpecifier[] | undefined> => {
   const fileUri = location.file;
 
+  const config = parseConfigFile(fileUri.fsPath);
+  const parsed = !!config;
+  setParsedConfigContext(parsed);
+
+  if (!parsed) {
+    return undefined;
+  }
+
   try {
-    const config = parseConfigFile(fileUri.fsPath);
     const storiesConfigItems = await getStoriesGlobs(config.stories);
     const configDirPath = location.dir.fsPath;
 

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -6,6 +6,8 @@ export const internalServerRunningContext =
   'storyExplorer.internalServerRunning';
 export const storybookConfigDetectedContext =
   'storyExplorer.storybookConfigDetected';
+export const storybookConfigParsedContext =
+  'storyExplorer.storybookConfigParsed';
 export const storybookPreviewFocusedContext =
   'storyExplorer.storybookPreviewFocused';
 export const storybookWebviewsOpenContext =
@@ -19,8 +21,8 @@ export const openPreviewCommand = 'storyExplorer.openPreview';
 export const openPreviewInBrowserCommand = 'storyExplorer.openPreviewInBrowser';
 export const openPreviewToSideCommand = 'storyExplorer.openPreviewToSide';
 export const openStorybookConfigCommand = 'storyExplorer.openStorybookConfig';
-export const openStorybookConfigDirSettingCommand =
-  'storyExplorer.openStorybookConfigDirSetting';
+export const openStoriesGlobsSettingCommand =
+  'storyExplorer.openStoriesGlobsSetting';
 export const openStorybookInBrowserCommand =
   'storyExplorer.openStorybookInBrowser';
 export const openStorybookUrlSettingCommand =
@@ -46,6 +48,7 @@ export const serverInternalEnvironmentVariablesConfigSuffix =
   'server.internal.environmentVariables';
 export const serverInternalStorybookBinaryPathConfigSuffix =
   'server.internal.storybookBinaryPath';
+export const storiesGlobsConfigSuffix = 'storiesGlobs';
 export const storiesViewShowItemsWithoutStoriesConfigSuffix =
   'storiesView.showItemsWithoutStories';
 export const storybookConfigDirConfigSuffix = 'storybookConfigDir';
@@ -58,6 +61,7 @@ export const serverExternalUrlConfig = makeFullConfigName(
 export const serverInternalStorybookBinaryPathConfig = makeFullConfigName(
   serverInternalStorybookBinaryPathConfigSuffix,
 );
+export const storiesGlobsConfig = makeFullConfigName(storiesGlobsConfigSuffix);
 export const storybookConfigDirConfig = makeFullConfigName(
   storybookConfigDirConfigSuffix,
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,8 @@ import { goToStorySource } from './commands/goToStorySource';
 import { openOutputChannel } from './commands/openOutputChannel';
 import { openPreview } from './commands/openPreview';
 import { openPreviewInBrowser } from './commands/openPreviewInBrowser';
+import { openStoriesGlobsSetting } from './commands/openStoriesGlobsSetting';
 import { openStorybookConfig } from './commands/openStorybookConfig';
-import { openStorybookConfigDirSetting } from './commands/openStorybookConfigDirSetting';
 import { openStorybookInBrowser } from './commands/openStorybookInBrowser';
 import { openStorybookUrlSetting } from './commands/openStorybookUrlSetting';
 import { refreshAllWebviews } from './commands/refreshAllWebviews';
@@ -24,8 +24,8 @@ import {
   openPreviewCommand,
   openPreviewInBrowserCommand,
   openPreviewToSideCommand,
+  openStoriesGlobsSettingCommand,
   openStorybookConfigCommand,
-  openStorybookConfigDirSettingCommand,
   openStorybookInBrowserCommand,
   openStorybookUrlSettingCommand,
   refreshAllWebviewsCommand,
@@ -104,11 +104,8 @@ export const activate = async (context: ExtensionContext) => {
       openPreviewInBrowserCommand,
       openPreviewInBrowser(webviewManager, storyStore, serverManager),
     );
+    registerCommand(openStoriesGlobsSettingCommand, openStoriesGlobsSetting());
     registerCommand(openStorybookUrlSettingCommand, openStorybookUrlSetting());
-    registerCommand(
-      openStorybookConfigDirSettingCommand,
-      openStorybookConfigDirSetting(),
-    );
     registerCommand(
       openStorybookConfigCommand,
       openStorybookConfig(configManager),

--- a/src/storybook/parseConfig.ts
+++ b/src/storybook/parseConfig.ts
@@ -1,3 +1,4 @@
+import { logWarn } from '../log/log';
 import type { StorybookConfig } from './StorybookConfig';
 
 const requireUncached = <T>(filePath: string): T => {
@@ -7,5 +8,11 @@ const requireUncached = <T>(filePath: string): T => {
 };
 
 export const parseConfigFile = (configFilePath: string) => {
-  return requireUncached<StorybookConfig>(configFilePath);
+  try {
+    return requireUncached<StorybookConfig>(configFilePath);
+  } catch (e) {
+    logWarn('Failed to read config file', e, configFilePath);
+  }
+
+  return undefined;
 };


### PR DESCRIPTION
Provide a more specific message when no stories can be found due to
failure to parse the detected configuration file. This can help
troubleshooting why stories might fail to be detected in certain
projects.