### PR TITLE
feat: support passing custom args to start-storybook script

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Controls when to automatically start a Storybook development server. This settin
 
 - `deferred`: Wait to start the server automatically until a story preview is opened.
 
+### `storyExplorer.server.internal.commandLineArgs`
+
+Array of command line arguments to pass to the `start-storybook` script.
+
 ### `storyExplorer.server.internal.enabled`
 
 Controls whether to enable the internal Storybook development server. When unchecked, you will have to run the server externally.

--- a/package.json
+++ b/package.json
@@ -223,6 +223,23 @@
           ],
           "default": null
         },
+        "storyExplorer.server.internal.commandLineArgs": {
+          "scope": "window",
+          "markdownDescription": "Array of command line arguments to pass to the `start-storybook` script.",
+          "type": "array",
+          "items": {
+            "type": [
+              "string",
+              "number"
+            ]
+          },
+          "examples": [
+            [
+              "-p",
+              "6006"
+            ]
+          ]
+        },
         "storyExplorer.server.internal.environmentVariables": {
           "scope": "window",
           "markdownDescription": "Object with environment variables that will be added to the Storybook server process.",
@@ -409,6 +426,7 @@
     "deploy": "vsce publish --packagePath story-explorer-*.vsix",
     "format": "prettier --check '{.vscode,src}/**/*.{json,ts}' '*.{json,md}'",
     "format:fix": "npm run -s format -- --write",
+    "generate-settings-markdown": "node -r ts-eager/register ./scripts/generateSettingsReadmeMarkdown.ts",
     "lint": "eslint src --ext ts --max-warnings 0",
     "lint:fix": "npm run -s lint -- --fix",
     "release": "standard-version",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -43,6 +43,8 @@ export const codeLensStoriesEnabledConfigSuffix = 'codeLens.stories.enabled';
 export const logLevelConfigSuffix = 'logLevel';
 export const serverExternalUrlConfigSuffix = 'server.external.url';
 export const serverInternalBehaviorConfigSuffix = 'server.internal.behavior';
+export const serverInternalCommandLineArgsConfigSuffix =
+  'server.internal.commandLineArgs';
 export const serverInternalEnabledConfigSuffix = 'server.internal.enabled';
 export const serverInternalEnvironmentVariablesConfigSuffix =
   'server.internal.environmentVariables';


### PR DESCRIPTION
Add a setting to allow passing additional command line arguments to the
start-storybook script when using the internal Storybook development
server.

Fixes #121