### PR TITLE
fix: initially expand tree node for active file

### DIFF
--- a/src/tree/TreeNodeItem.ts
+++ b/src/tree/TreeNodeItem.ts
@@ -2,11 +2,13 @@ import {
   ExtensionContext,
   TreeItem,
   TreeItemCollapsibleState,
+  window,
   workspace,
 } from 'vscode';
 import { createOpenInEditorCommand } from '../util/createOpenCommand';
 import { getIconPath } from '../util/getIconPath';
 import type { TreeNode } from './TreeNode';
+import { findEntryByUri } from './findEntryByUri';
 
 const getDefaultCollapsedState = (
   entry: TreeNode,
@@ -16,10 +18,17 @@ const getDefaultCollapsedState = (
   }
 
   const isTopLevel = !entry.parent;
+  if (isTopLevel) {
+    return TreeItemCollapsibleState.Expanded;
+  }
 
-  return isTopLevel
-    ? TreeItemCollapsibleState.Expanded
-    : TreeItemCollapsibleState.Collapsed;
+  const activeUri = window.activeTextEditor?.document.uri;
+  const hasActiveFile = activeUri && !!findEntryByUri([entry], activeUri);
+  if (hasActiveFile) {
+    return TreeItemCollapsibleState.Expanded;
+  }
+
+  return TreeItemCollapsibleState.Collapsed;
 };
 
 export class TreeNodeItem extends TreeItem {

--- a/src/tree/TreeViewManager.ts
+++ b/src/tree/TreeViewManager.ts
@@ -12,26 +12,7 @@ import { logWarn } from '../log/log';
 import type { StoryStore } from '../store/StoryStore';
 import { StoryTreeDataProvider } from './StoryTreeDataProvider';
 import type { TreeNode } from './TreeNode';
-
-const findEntryByUri = (
-  entries: Iterable<TreeNode>,
-  uri: Uri,
-): TreeNode | undefined => {
-  for (const entry of entries) {
-    if (entry.type === 'kind') {
-      if (entry.matchesUri(uri)) {
-        return entry;
-      }
-
-      const result = findEntryByUri(entry.getChildren(), uri);
-      if (result) {
-        return result;
-      }
-    }
-  }
-
-  return undefined;
-};
+import { findEntryByUri } from './findEntryByUri';
 
 const findEntryByStoryId = (
   entries: Iterable<TreeNode>,

--- a/src/tree/findEntryByUri.ts
+++ b/src/tree/findEntryByUri.ts
@@ -1,0 +1,22 @@
+import type { Uri } from 'vscode';
+import type { TreeNode } from './TreeNode';
+
+export const findEntryByUri = (
+  entries: Iterable<TreeNode>,
+  uri: Uri,
+): TreeNode | undefined => {
+  for (const entry of entries) {
+    if (entry.type === 'kind') {
+      if (entry.matchesUri(uri)) {
+        return entry;
+      }
+
+      const result = findEntryByUri(entry.getChildren(), uri);
+      if (result) {
+        return result;
+      }
+    }
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
When creating a new TreeNodeItem, expand it by default if a file
corresponding to that item (or one of its children, however deeply
nested) is active.

This is consistent with behavior when activating a file whose
TreeNodeItem already exists, and improves the experience when a story
file is discovered or added for any reason while its editor is already
open (e.g., the file becomes syntactically valid).