### PR TITLE
chore: fix moduleNameMapper

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -11,7 +11,7 @@ export default /**
   coverageProvider: 'v8',
   coverageReporters: ['text'],
   moduleNameMapper: {
-    vscode: join(__dirname, 'vscode.js'),
+    '^vscode$': join(__dirname, 'vscode.js'),
   },
   roots: ['src'],
   transform: {


### PR DESCRIPTION
The key is a regular expression, not a string literal.