### PR TITLE
perf: limit concurrent find operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4098,6 +4098,17 @@
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
+          },
+          "dependencies": {
+            "p-limit": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            }
           }
         },
         "path-exists": {
@@ -10083,12 +10094,20 @@
       "dev": true
     },
     "p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
       "dev": true,
       "requires": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^1.0.0"
+      },
+      "dependencies": {
+        "yocto-queue": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+          "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+          "dev": true
+        }
       }
     },
     "p-locate": {
@@ -10098,6 +10117,17 @@
       "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        }
       }
     },
     "p-try": {

--- a/package.json
+++ b/package.json
@@ -467,6 +467,7 @@
     "jest": "28.1.0",
     "lodash": "4.17.21",
     "node-netstat": "1.8.0",
+    "p-limit": "4.0.0",
     "picomatch": "2.3.0",
     "prettier": "2.6.2",
     "standard-version": "9.3.2",

--- a/src/store/findFilesByGlob.ts
+++ b/src/store/findFilesByGlob.ts
@@ -19,11 +19,3 @@ export const findFilesByGlob = async (globSpecifier: GlobSpecifier) => {
 
   return findResults;
 };
-
-export const findFilesByGlobs = async (globSpecifiers: GlobSpecifier[]) => {
-  return (
-    await Promise.all(
-      globSpecifiers.map((globSpecifier) => findFilesByGlob(globSpecifier)),
-    )
-  ).flat();
-};


### PR DESCRIPTION
Limit the number of concurrent searches that are allowed to a hardcoded
value of 3. This can help avoid overtaxing the CPU when performing an
initial search for stories files for a project that has many glob
specifiers.