### PR TITLE
feat: make some settings language-overridable

### DIFF
--- a/package.json
+++ b/package.json
@@ -286,13 +286,13 @@
           ]
         },
         "storyExplorer.codeLens.stories.enabled": {
-          "scope": "window",
+          "scope": "language-overridable",
           "markdownDescription": "Controls whether to display CodeLens results for stories. When enabled, CodeLens results for stories appear above story definitions.",
           "type": "boolean",
           "default": true
         },
         "storyExplorer.codeLens.docs.enabled": {
-          "scope": "window",
+          "scope": "language-overridable",
           "markdownDescription": "Controls whether to display CodeLens results for docs. When enabled, CodeLens results for docs appear at the top of story files.",
           "type": "boolean",
           "default": true
@@ -304,13 +304,13 @@
           "default": false
         },
         "storyExplorer.suggestTitle": {
-          "scope": "window",
+          "scope": "language-overridable",
           "markdownDescription": "Controls whether to offer suggestions for titles when specifying a `Meta` object in CSF or MDX files. Suggestions are based on other titles used in the project.",
           "type": "boolean",
           "default": true
         },
         "storyExplorer.suggestStoryId": {
-          "scope": "window",
+          "scope": "language-overridable",
           "markdownDescription": "Controls whether to offer suggestions for story IDs when using `<Story id=\"...\" />` in MDX files. Suggestions are based on the IDs of other stories in the project.",
           "type": "boolean",
           "default": true

--- a/src/codelens/CodeLensManager.ts
+++ b/src/codelens/CodeLensManager.ts
@@ -77,10 +77,7 @@ export class CodeLensManager {
   }
 
   private shouldEnable() {
-    return (
-      this.docsSettingsWatcher.read() !== false ||
-      this.storiesSettingsWatcher.read() !== false
-    );
+    return true;
   }
 
   private refresh() {

--- a/src/codelens/StoryCodeLensProvider.ts
+++ b/src/codelens/StoryCodeLensProvider.ts
@@ -53,8 +53,12 @@ export class StoryCodeLensProvider implements CodeLensProvider {
   }
 
   public provideCodeLenses(document: TextDocument): CodeLens[] | undefined {
-    const showStories = this.storiesSettingsWatcher.read() !== false;
-    const showDocs = this.docsSettingsWatcher.read() !== false;
+    const showStories = this.storiesSettingsWatcher.read(document) !== false;
+    const showDocs = this.docsSettingsWatcher.read(document) !== false;
+
+    if (!showStories && !showDocs) {
+      return;
+    }
 
     // FUTURE: instead of parsing the file again, consider re-using existing
     // results in the story store. Would need to make sure results aren't stale

--- a/src/completion/CsfTitleCompletionProvider.ts
+++ b/src/completion/CsfTitleCompletionProvider.ts
@@ -6,6 +6,7 @@ import type {
   TextDocument,
 } from 'vscode';
 import type { StoryStore } from '../store/StoryStore';
+import type { SettingsWatcher } from '../util/SettingsWatcher';
 import type { TextCompletionItem } from './TextCompletionItem';
 import { getRangeForCompletion } from './getRangeForCompletion';
 import { getStoryKindCompletionItems } from './getStoryKindCompletionItems';
@@ -13,12 +14,19 @@ import { getStoryKindCompletionItems } from './getStoryKindCompletionItems';
 export class CsfTitleCompletionProvider
   implements CompletionItemProvider<TextCompletionItem>
 {
-  public constructor(private readonly storyStore: StoryStore) {}
+  public constructor(
+    private readonly storyStore: StoryStore,
+    private readonly settingsWatcher: SettingsWatcher<boolean>,
+  ) {}
 
   public provideCompletionItems(
     document: TextDocument,
     position: Position,
   ): ProviderResult<TextCompletionItem[] | CompletionList<TextCompletionItem>> {
+    if (!this.settingsWatcher.read(document)) {
+      return undefined;
+    }
+
     // FUTURE: reduce false positives, e.g., by determining if the position
     // appears to be defining a title property for the default (Meta) export
 

--- a/src/completion/IdCompletionManager.ts
+++ b/src/completion/IdCompletionManager.ts
@@ -9,7 +9,7 @@ export class IdCompletionManager {
   private mdxIdProvider?: MdxStoryIdCompletionProvider;
   private mdxIdRegistration?: Disposable;
 
-  private readonly settingsWatcher = new SettingsWatcher(
+  private readonly settingsWatcher = new SettingsWatcher<boolean>(
     suggestStoryIdConfigSuffix,
     () => {
       this.startIfEnabled();
@@ -26,7 +26,10 @@ export class IdCompletionManager {
 
   public start() {
     if (!this.mdxIdProvider) {
-      this.mdxIdProvider = new MdxStoryIdCompletionProvider(this.storyStore);
+      this.mdxIdProvider = new MdxStoryIdCompletionProvider(
+        this.storyStore,
+        this.settingsWatcher,
+      );
       this.mdxIdRegistration = languages.registerCompletionItemProvider(
         [{ language: 'markdown' }, { language: 'mdx' }],
         this.mdxIdProvider,
@@ -49,7 +52,7 @@ export class IdCompletionManager {
   }
 
   private shouldEnable() {
-    return this.settingsWatcher.read() !== false;
+    return true;
   }
 
   private startIfEnabled() {

--- a/src/completion/MdxStoryIdCompletionProvider.ts
+++ b/src/completion/MdxStoryIdCompletionProvider.ts
@@ -7,18 +7,26 @@ import {
   workspace,
 } from 'vscode';
 import type { StoryStore } from '../store/StoryStore';
+import type { SettingsWatcher } from '../util/SettingsWatcher';
 import { TextCompletionItem } from './TextCompletionItem';
 import { getRangeForCompletion } from './getRangeForCompletion';
 
 export class MdxStoryIdCompletionProvider
   implements CompletionItemProvider<TextCompletionItem>
 {
-  public constructor(private readonly storyStore: StoryStore) {}
+  public constructor(
+    private readonly storyStore: StoryStore,
+    private readonly settingsWatcher: SettingsWatcher<boolean>,
+  ) {}
 
   public provideCompletionItems(
     document: TextDocument,
     position: Position,
   ): ProviderResult<TextCompletionItem[] | CompletionList<TextCompletionItem>> {
+    if (!this.settingsWatcher.read(document)) {
+      return undefined;
+    }
+
     // FUTURE: reduce false positives, e.g., by determining if the position
     // appears to be within props for a `<Story />` element
 

--- a/src/completion/MdxTitleCompletionProvider.ts
+++ b/src/completion/MdxTitleCompletionProvider.ts
@@ -6,6 +6,7 @@ import type {
   TextDocument,
 } from 'vscode';
 import type { StoryStore } from '../store/StoryStore';
+import type { SettingsWatcher } from '../util/SettingsWatcher';
 import type { TextCompletionItem } from './TextCompletionItem';
 import { getRangeForCompletion } from './getRangeForCompletion';
 import { getStoryKindCompletionItems } from './getStoryKindCompletionItems';
@@ -13,12 +14,19 @@ import { getStoryKindCompletionItems } from './getStoryKindCompletionItems';
 export class MdxTitleCompletionProvider
   implements CompletionItemProvider<TextCompletionItem>
 {
-  public constructor(private readonly storyStore: StoryStore) {}
+  public constructor(
+    private readonly storyStore: StoryStore,
+    private readonly settingsWatcher: SettingsWatcher<boolean>,
+  ) {}
 
   public provideCompletionItems(
     document: TextDocument,
     position: Position,
   ): ProviderResult<TextCompletionItem[] | CompletionList<TextCompletionItem>> {
+    if (!this.settingsWatcher.read(document)) {
+      return undefined;
+    }
+
     // FUTURE: reduce false positives, e.g., by determining if the position
     // appears to be within props for a `<Meta />` element
 

--- a/src/completion/TitleCompletionManager.ts
+++ b/src/completion/TitleCompletionManager.ts
@@ -14,7 +14,7 @@ export class TitleCompletionManager {
   private mdxProvider?: MdxTitleCompletionProvider;
   private mdxRegistration?: Disposable;
 
-  private readonly settingsWatcher = new SettingsWatcher(
+  private readonly settingsWatcher = new SettingsWatcher<boolean>(
     suggestTitleConfigSuffix,
     () => {
       this.startIfEnabled();
@@ -31,7 +31,10 @@ export class TitleCompletionManager {
 
   public start() {
     if (!this.csfProvider) {
-      this.csfProvider = new CsfTitleCompletionProvider(this.storyStore);
+      this.csfProvider = new CsfTitleCompletionProvider(
+        this.storyStore,
+        this.settingsWatcher,
+      );
       this.csfRegistration = languages.registerCompletionItemProvider(
         [
           { language: 'javascript' },
@@ -46,7 +49,10 @@ export class TitleCompletionManager {
     }
 
     if (!this.mdxProvider) {
-      this.mdxProvider = new MdxTitleCompletionProvider(this.storyStore);
+      this.mdxProvider = new MdxTitleCompletionProvider(
+        this.storyStore,
+        this.settingsWatcher,
+      );
       this.mdxRegistration = languages.registerCompletionItemProvider(
         [{ language: 'markdown' }, { language: 'mdx' }],
         this.mdxProvider,
@@ -74,7 +80,7 @@ export class TitleCompletionManager {
   }
 
   private shouldEnable() {
-    return this.settingsWatcher.read() !== false;
+    return true;
   }
 
   private startIfEnabled() {

--- a/src/util/SettingsWatcher.ts
+++ b/src/util/SettingsWatcher.ts
@@ -1,4 +1,4 @@
-import { Disposable, workspace } from 'vscode';
+import { ConfigurationScope, Disposable, workspace } from 'vscode';
 import { configPrefix } from '../constants/constants';
 import { logError } from '../log/log';
 import { makeFullConfigName } from './makeFullConfigName';
@@ -23,8 +23,8 @@ export class SettingsWatcher<T = unknown> {
     });
   }
 
-  public read() {
-    return workspace.getConfiguration(configPrefix).get<T>(this.setting);
+  public read(scope?: ConfigurationScope) {
+    return workspace.getConfiguration(configPrefix, scope).get<T>(this.setting);
   }
 
   public dispose() {


### PR DESCRIPTION
Update some settings to be language-overridable:
- `storyExplorer.codeLens.stories.enabled`
- `storyExplorer.codeLens.docs.enabled`
- `storyExplorer.suggestTitle`
- `storyExplorer.suggestStoryId`

This allows these settings to be enabled or disabled on a per-language
basis; e.g., title suggestions may be enabled in JavaScript files but
disabled for MDX files in the same workspace.