### PR TITLE
fix: improve filesystem compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3360,7 +3360,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true
     },
     "code-point-at": {
@@ -3883,7 +3883,7 @@
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
     },
     "deep-extend": {
@@ -4959,7 +4959,7 @@
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
       "dev": true
     },
     "expand-brackets": {
@@ -12148,6 +12148,12 @@
         "yauzl": "^2.3.1",
         "yazl": "^2.2.2"
       }
+    },
+    "vscode-uri": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
+      "integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==",
+      "dev": true
     },
     "walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -473,6 +473,7 @@
     "standard-version": "9.5.0",
     "ts-eager": "2.0.2",
     "typescript": "4.7.3",
-    "vsce": "2.9.1"
+    "vsce": "2.9.1",
+    "vscode-uri": "3.0.3"
   }
 }

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -1,3 +1,5 @@
+import { URI, Utils } from 'vscode-uri';
+
 export enum ExtensionMode {
   Production = 1,
   Development = 2,
@@ -9,3 +11,8 @@ export class RelativePattern {
     return { base, pattern };
   }
 }
+
+export const Uri = {
+  ...URI,
+  ...Utils,
+};

--- a/src/completion/CsfTitleCompletionProvider.ts
+++ b/src/completion/CsfTitleCompletionProvider.ts
@@ -39,11 +39,7 @@ export class CsfTitleCompletionProvider
     );
 
     if (range) {
-      return getStoryKindCompletionItems(
-        this.storyStore,
-        document.uri.fsPath,
-        range,
-      );
+      return getStoryKindCompletionItems(this.storyStore, document.uri, range);
     }
   }
 }

--- a/src/completion/MdxTitleCompletionProvider.ts
+++ b/src/completion/MdxTitleCompletionProvider.ts
@@ -39,11 +39,7 @@ export class MdxTitleCompletionProvider
     );
 
     if (range) {
-      return getStoryKindCompletionItems(
-        this.storyStore,
-        document.uri.fsPath,
-        range,
-      );
+      return getStoryKindCompletionItems(this.storyStore, document.uri, range);
     }
   }
 }

--- a/src/completion/getStoryKindCompletionItems.ts
+++ b/src/completion/getStoryKindCompletionItems.ts
@@ -1,10 +1,11 @@
+import type { Uri } from 'vscode';
 import type { StoryStore } from '../store/StoryStore';
 import { splitKind } from '../util/splitKind';
 import { TextCompletionItem } from './TextCompletionItem';
 
-const getStoryKindSegments = (storyStore: StoryStore, ignoreFsPath: string) => {
+const getStoryKindSegments = (storyStore: StoryStore, ignoreUri: Uri) => {
   return storyStore.getStoryFiles().reduce((acc, cur) => {
-    if (cur.getUri().fsPath !== ignoreFsPath) {
+    if (cur.getUri().toString() !== ignoreUri.toString()) {
       const title = cur.getTitle();
       if (title && typeof title === 'string') {
         const segments = splitKind(title);
@@ -20,10 +21,10 @@ const getStoryKindSegments = (storyStore: StoryStore, ignoreFsPath: string) => {
 
 export const getStoryKindCompletionItems = (
   storyStore: StoryStore,
-  ignoreFsPath: string,
+  ignoreUri: Uri,
   range: TextCompletionItem['range'],
 ) => {
-  const segmentSet = getStoryKindSegments(storyStore, ignoreFsPath);
+  const segmentSet = getStoryKindSegments(storyStore, ignoreUri);
 
   return Array.from(segmentSet.values()).map((title) =>
     TextCompletionItem.create(title, { range, commitCharacters: ['/'] }),

--- a/src/config/GlobSpecifier.ts
+++ b/src/config/GlobSpecifier.ts
@@ -1,5 +1,7 @@
+import type { Uri } from 'vscode';
+
 export interface GlobSpecifier {
-  directory: string;
+  directory: Uri;
   files: string;
   titlePrefix: string;
 }

--- a/src/config/StorybookConfigLocationDetector.ts
+++ b/src/config/StorybookConfigLocationDetector.ts
@@ -1,4 +1,5 @@
-import { EventEmitter, Uri, workspace } from 'vscode';
+import { EventEmitter, workspace } from 'vscode';
+import { Utils } from 'vscode-uri';
 import { logError, logInfo, logWarn } from '../log/log';
 import { FileWatcher } from '../util/FileWatcher';
 import { RecursiveDeleteWatcher } from '../util/RecursiveDeleteWatcher';
@@ -72,8 +73,8 @@ export class StorybookConfigLocationDetectProvider
       (await this.fileWatcher?.find('**/node_modules/**')) ?? [];
     const configLocations = findResults.map((uri) => ({
       file: uri,
-      dir: Uri.joinPath(uri, '..'),
-      relativePath: workspace.asRelativePath(uri),
+      dir: Utils.dirname(uri),
+      relativePath: workspace.asRelativePath(uri, false),
     }));
 
     configLocations.sort((a, b) =>
@@ -95,7 +96,7 @@ export class StorybookConfigLocationDetectProvider
 
     const locationChanged =
       configLocation &&
-      configLocation.file.fsPath === this.configLocation?.file.fsPath;
+      configLocation.file.toString() === this.configLocation?.file.toString();
 
     if (locationChanged) {
       return configLocation;

--- a/src/config/storiesGlobsConfigProvider.ts
+++ b/src/config/storiesGlobsConfigProvider.ts
@@ -19,12 +19,12 @@ export const storiesGlobsConfigProvider = new SettingsConfigProvider(
     };
 
     const storiesConfigItems = sanitize();
-    const configDirPath = getWorkspaceRoot();
-    return storiesConfigItems
+    const configDir = getWorkspaceRoot();
+    return storiesConfigItems && configDir
       ? {
           value: await Promise.all(
             storiesConfigItems.map((configItem) =>
-              interpretStoriesConfigItem(configItem, configDirPath),
+              interpretStoriesConfigItem(configItem, configDir),
             ),
           ),
         }

--- a/src/config/storybookConfigLocationConfigProvider.ts
+++ b/src/config/storybookConfigLocationConfigProvider.ts
@@ -1,5 +1,5 @@
-import { resolve } from 'path';
 import { Uri } from 'vscode';
+import { Utils } from 'vscode-uri';
 import { getWorkspaceRoot } from '../util/getWorkspaceRoot';
 import { SettingsConfigProvider } from './SettingsConfigProvider';
 import type { StorybookConfigLocation } from './StorybookConfigLocation';
@@ -21,8 +21,12 @@ export const storybookConfigLocationConfigProvider = new SettingsConfigProvider<
     return undefined;
   }
 
-  const rootPath = getWorkspaceRoot();
-  const dir = Uri.file(resolve(rootPath, configDir));
+  const rootUri = getWorkspaceRoot();
+  if (!rootUri) {
+    return undefined;
+  }
+
+  const dir = Utils.resolvePath(rootUri, configDir);
   const file = Uri.joinPath(dir, 'main.js');
   return configDir
     ? {

--- a/src/globs/__snapshots__/convertGlob.test.ts.snap
+++ b/src/globs/__snapshots__/convertGlob.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`convertGlob handles ** 1`] = `
 Object {
-  "globBasePath": "/mock/baseDir",
+  "globBase": "file:///mock/baseDir",
   "globPattern": "**/*",
   "regex": /\\^\\(\\?:\\(\\?:\\(\\?:\\(\\?!\\(\\?:\\^\\|\\\\/\\)\\\\\\.\\)\\.\\)\\*\\?\\)\\)\\$/,
 }
@@ -10,7 +10,7 @@ Object {
 
 exports[`convertGlob handles **/* 1`] = `
 Object {
-  "globBasePath": "/mock/baseDir",
+  "globBase": "file:///mock/baseDir",
   "globPattern": "**/*",
   "regex": /\\^\\(\\?:\\(\\?:\\^\\|\\\\/\\|\\(\\?:\\(\\?:\\(\\?!\\(\\?:\\^\\|\\\\/\\)\\\\\\.\\)\\.\\)\\*\\?\\)\\\\/\\)\\(\\?!\\\\\\.\\)\\(\\?=\\.\\)\\[\\^/\\]\\*\\?\\\\/\\?\\)\\$/,
 }
@@ -18,7 +18,7 @@ Object {
 
 exports[`convertGlob handles **/*.stories.@(js|jsx|ts|tsx) 1`] = `
 Object {
-  "globBasePath": "/mock/baseDir",
+  "globBase": "file:///mock/baseDir",
   "globPattern": "**/*",
   "regex": /\\^\\(\\?:\\(\\?:\\^\\|\\\\/\\|\\(\\?:\\(\\?:\\(\\?!\\(\\?:\\^\\|\\\\/\\)\\\\\\.\\)\\.\\)\\*\\?\\)\\\\/\\)\\(\\?!\\\\\\.\\)\\(\\?=\\.\\)\\[\\^/\\]\\*\\?\\\\\\.stories\\\\\\.\\(js\\|jsx\\|ts\\|tsx\\)\\)\\$/,
 }
@@ -26,7 +26,7 @@ Object {
 
 exports[`convertGlob handles **/../*.ts 1`] = `
 Object {
-  "globBasePath": "/mock/baseDir",
+  "globBase": "file:///mock/baseDir",
   "globPattern": "**/*",
   "regex": /\\^\\(\\?:\\(\\?:\\^\\|\\\\/\\|\\(\\?:\\(\\?:\\(\\?!\\(\\?:\\^\\|\\\\/\\)\\\\\\.\\)\\.\\)\\*\\?\\)\\\\/\\)\\\\\\.\\\\\\.\\\\/\\(\\?!\\\\\\.\\)\\(\\?=\\.\\)\\[\\^/\\]\\*\\?\\\\\\.ts\\)\\$/,
 }
@@ -34,7 +34,7 @@ Object {
 
 exports[`convertGlob handles ../src/**/*.stories.@(js|jsx|ts|tsx) 1`] = `
 Object {
-  "globBasePath": "/mock/src",
+  "globBase": "file:///mock/src",
   "globPattern": "**/*",
   "regex": /\\^\\(\\?:\\(\\?:\\^\\|\\\\/\\|\\(\\?:\\(\\?:\\(\\?!\\(\\?:\\^\\|\\\\/\\)\\\\\\.\\)\\.\\)\\*\\?\\)\\\\/\\)\\(\\?!\\\\\\.\\)\\(\\?=\\.\\)\\[\\^/\\]\\*\\?\\\\\\.stories\\\\\\.\\(js\\|jsx\\|ts\\|tsx\\)\\)\\$/,
 }
@@ -42,7 +42,7 @@ Object {
 
 exports[`convertGlob handles ../src/**/*.stories.mdx 1`] = `
 Object {
-  "globBasePath": "/mock/src",
+  "globBase": "file:///mock/src",
   "globPattern": "**/*",
   "regex": /\\^\\(\\?:\\(\\?:\\^\\|\\\\/\\|\\(\\?:\\(\\?:\\(\\?!\\(\\?:\\^\\|\\\\/\\)\\\\\\.\\)\\.\\)\\*\\?\\)\\\\/\\)\\(\\?!\\\\\\.\\)\\(\\?=\\.\\)\\[\\^/\\]\\*\\?\\\\\\.stories\\\\\\.mdx\\)\\$/,
 }
@@ -50,7 +50,7 @@ Object {
 
 exports[`convertGlob handles @(js|jsx|ts|tsx) 1`] = `
 Object {
-  "globBasePath": "/mock/baseDir",
+  "globBase": "file:///mock/baseDir",
   "globPattern": "**/*",
   "regex": /\\^\\(\\?:\\(js\\|jsx\\|ts\\|tsx\\)\\)\\$/,
 }
@@ -58,13 +58,13 @@ Object {
 
 exports[`convertGlob handles file.ts 1`] = `
 Object {
-  "globPattern": "/mock/baseDir/file.ts",
+  "globBase": "file:///mock/baseDir/file.ts",
 }
 `;
 
 exports[`convertGlob handles src/* 1`] = `
 Object {
-  "globBasePath": "/mock/baseDir/src",
+  "globBase": "file:///mock/baseDir/src",
   "globPattern": "**/*",
   "regex": /\\^\\(\\?:\\(\\?!\\\\\\.\\)\\(\\?=\\.\\)\\[\\^/\\]\\*\\?\\\\/\\?\\)\\$/,
 }
@@ -72,7 +72,7 @@ Object {
 
 exports[`convertGlob handles src/** 1`] = `
 Object {
-  "globBasePath": "/mock/baseDir/src",
+  "globBase": "file:///mock/baseDir/src",
   "globPattern": "**/*",
   "regex": /\\^\\(\\?:\\(\\?:\\(\\?:\\(\\?!\\(\\?:\\^\\|\\\\/\\)\\\\\\.\\)\\.\\)\\*\\?\\)\\)\\$/,
 }
@@ -80,7 +80,7 @@ Object {
 
 exports[`convertGlob handles src/**/*.ts 1`] = `
 Object {
-  "globBasePath": "/mock/baseDir/src",
+  "globBase": "file:///mock/baseDir/src",
   "globPattern": "**/*",
   "regex": /\\^\\(\\?:\\(\\?:\\^\\|\\\\/\\|\\(\\?:\\(\\?:\\(\\?!\\(\\?:\\^\\|\\\\/\\)\\\\\\.\\)\\.\\)\\*\\?\\)\\\\/\\)\\(\\?!\\\\\\.\\)\\(\\?=\\.\\)\\[\\^/\\]\\*\\?\\\\\\.ts\\)\\$/,
 }
@@ -88,6 +88,6 @@ Object {
 
 exports[`convertGlob handles src/file.ts 1`] = `
 Object {
-  "globPattern": "/mock/baseDir/src/file.ts",
+  "globBase": "file:///mock/baseDir/src/file.ts",
 }
 `;

--- a/src/globs/convertGlob.test.ts
+++ b/src/globs/convertGlob.test.ts
@@ -1,3 +1,4 @@
+import { URI } from 'vscode-uri';
 import { convertGlob } from './convertGlob';
 
 describe('convertGlob', () => {
@@ -104,7 +105,7 @@ describe('convertGlob', () => {
   inputs.forEach(([input, match = undefined, noMatch = undefined]) =>
     it(`handles ${input}`, () => {
       const { filter, ...result } = convertGlob({
-        directory: '/mock/baseDir',
+        directory: URI.file('/mock/baseDir'),
         files: input,
         titlePrefix: '',
       });
@@ -116,13 +117,18 @@ describe('convertGlob', () => {
       }
 
       (match ?? []).forEach((path) => {
-        expect(filter!(path)).toBe(true);
+        expect(filter!(URI.file(path))).toBe(true);
       });
       (noMatch ?? []).forEach((path) => {
-        expect(filter!(path)).toBe(false);
+        expect(filter!(URI.file(path))).toBe(false);
       });
 
-      expect(result).toMatchSnapshot();
+      const normalizedResult = {
+        ...result,
+        globBase: result.globBase.toString(),
+      };
+
+      expect(normalizedResult).toMatchSnapshot();
     }),
   );
 });

--- a/src/globs/convertGlob.ts
+++ b/src/globs/convertGlob.ts
@@ -1,13 +1,25 @@
 import { relative } from 'path';
+import type { Uri } from 'vscode';
 import type { GlobSpecifier } from '../config/GlobSpecifier';
 import { getGlobInfo } from './getGlobInfo';
 
-interface ConvertedGlob {
-  globPattern: string;
-  globBasePath?: string;
-  filter?: (path: string) => boolean;
-  regex?: RegExp;
+interface ConvertedGlobWithoutPattern {
+  globBase: Uri;
+  globPattern?: never;
+  filter?: never;
+  regex?: never;
 }
+
+interface ConvertedGlobWithPattern {
+  globBase: Uri;
+  globPattern: string;
+  filter: (uri: Uri) => boolean;
+  regex: RegExp;
+}
+
+export type ConvertedGlob =
+  | ConvertedGlobWithoutPattern
+  | ConvertedGlobWithPattern;
 
 // FUTURE: it may be possible to convert a subset of globs (where `isGlob` is
 // true) to a VS Code-compatible form that doesn't require post-filtering
@@ -16,17 +28,21 @@ export const convertGlob = (globSpecifier: GlobSpecifier): ConvertedGlob => {
 
   if (!globInfo.isGlob) {
     return {
-      globPattern: globInfo.basePath,
+      globBase: globInfo.base,
     };
   }
 
-  const { basePath, regex } = globInfo;
+  const { base, regex } = globInfo;
 
   return {
-    globBasePath: basePath,
+    globBase: base,
     globPattern: '**/*',
-    filter: (path) => {
-      const relativePath = relative(basePath, path);
+    filter: (uri) => {
+      if (base.scheme !== uri.scheme || base.authority !== uri.authority) {
+        return false;
+      }
+
+      const relativePath = relative(base.path, uri.path);
       return regex.test(relativePath);
     },
     regex,

--- a/src/globs/getGlobInfo.ts
+++ b/src/globs/getGlobInfo.ts
@@ -1,9 +1,9 @@
-import { resolve } from 'path';
 import { makeRe, scan } from 'picomatch';
+import { Utils } from 'vscode-uri';
 import type { GlobSpecifier } from '../config/GlobSpecifier';
 
 export const getGlobInfo = ({ directory, files }: GlobSpecifier) => {
-  const glob = `${directory}/${files}`;
+  const glob = `${directory.path}/${files}`;
 
   const globOptions = {
     fastpaths: false,
@@ -14,11 +14,14 @@ export const getGlobInfo = ({ directory, files }: GlobSpecifier) => {
   const scanInfo = scan(glob, { ...globOptions, tokens: true });
 
   if (scanInfo.isGlob) {
-    const basePath = resolve(directory, scanInfo.base);
+    const base = Utils.resolvePath(directory, scanInfo.base);
     const regex = makeRe(scanInfo.glob, globOptions);
 
-    return { basePath, regex, isGlob: true as const };
-  } else {
-    return { basePath: scanInfo.base, isGlob: false as const };
+    return { base, regex, isGlob: true as const };
   }
+
+  return {
+    base: directory.with({ path: scanInfo.base }),
+    isGlob: false as const,
+  };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,9 @@ export const activate = async (context: ExtensionContext) => {
     const treeViewManager = addSubscription(
       TreeViewManager.init(context, storyStore),
     );
-    const proxyManager = addSubscription(ProxyManager.init(serverManager));
+    const proxyManager = addSubscription(
+      ProxyManager.init(serverManager, context.extensionUri),
+    );
     const webviewManager = addSubscription(
       WebviewManager.init(
         context,

--- a/src/proxy/ProxyManager.ts
+++ b/src/proxy/ProxyManager.ts
@@ -1,3 +1,4 @@
+import type { Uri } from 'vscode';
 import type { ServerManager } from '../server/ServerManager';
 import { Cacheable } from '../util/Cacheable';
 import { ProxyServer } from './ProxyServer';
@@ -6,15 +7,18 @@ export class ProxyManager {
   private proxyServer?: ProxyServer;
 
   private readonly proxyServerCacheable = new Cacheable(() => {
-    this.proxyServer = new ProxyServer(this.serverManager);
+    this.proxyServer = new ProxyServer(this.serverManager, this.extensionUri);
 
     return this.proxyServer;
   });
 
-  private constructor(private readonly serverManager: ServerManager) {}
+  private constructor(
+    private readonly serverManager: ServerManager,
+    private readonly extensionUri: Uri,
+  ) {}
 
-  public static init(serverManager: ServerManager) {
-    return new ProxyManager(serverManager);
+  public static init(serverManager: ServerManager, extensionUri: Uri) {
+    return new ProxyManager(serverManager, extensionUri);
   }
 
   public ensureProxyServer() {

--- a/src/server/StorybookServer.ts
+++ b/src/server/StorybookServer.ts
@@ -1,11 +1,10 @@
 import type { IncomingMessage } from 'http';
-import { ProgressLocation, window } from 'vscode';
+import { ProgressLocation, window, workspace } from 'vscode';
 import type { ConfigManager } from '../config/ConfigManager';
 import { internalServerRunningContext } from '../constants/constants';
 import { logDebug, logError, logInfo } from '../log/log';
 import { Cacheable } from '../util/Cacheable';
 import { Mailbox } from '../util/Mailbox';
-import { getWorkspaceRoot } from '../util/getWorkspaceRoot';
 import { poll } from '../util/poll';
 import { setContext } from '../util/setContext';
 import { TaskExecutor } from './TaskExecutor';
@@ -159,14 +158,16 @@ export class StorybookServer {
 
   private async createTask() {
     const binPath = await getStorybookBinPath();
-    const cwd = getWorkspaceRoot();
-    const configDirPath = this.configManager.getConfigDir()?.path;
+    const configDir = this.configManager.getConfigDir();
+    const cwd = configDir
+      ? workspace.getWorkspaceFolder(configDir)?.uri
+      : undefined;
 
     if (!binPath) {
       return undefined;
     }
 
-    return createTask(binPath, cwd, configDirPath);
+    return createTask(binPath, cwd, configDir);
   }
 
   private readonly cleanupAfterTaskExit = () => {

--- a/src/server/createTask.ts
+++ b/src/server/createTask.ts
@@ -3,6 +3,7 @@ import {
   Task,
   TaskRevealKind,
   TaskScope,
+  Uri,
   workspace,
 } from 'vscode';
 import {
@@ -56,17 +57,17 @@ const getArgs = () => {
 
 export const createTask = (
   binPath: string,
-  cwd: string,
-  configDirPath: string | undefined,
+  cwd: Uri | undefined,
+  configDir: Uri | undefined,
 ) => {
   const processExecution = new ProcessExecution(
     'node',
     [binPath, ...(getArgs() ?? [])],
     {
-      cwd,
+      cwd: cwd?.fsPath,
       env: {
         CI: 'true',
-        ...(configDirPath && { SBCONFIG_CONFIG_DIR: configDirPath }),
+        ...(configDir && { SBCONFIG_CONFIG_DIR: configDir.fsPath }),
         ...getEnvironmentVariables(),
       },
     },

--- a/src/server/getStorybookBinPath.ts
+++ b/src/server/getStorybookBinPath.ts
@@ -14,7 +14,7 @@ const getDetectedStorybookBinPath = async (): Promise<string | undefined> => {
   const [match] = matches
     .map((uri) => ({
       uri,
-      relativePath: workspace.asRelativePath(uri),
+      relativePath: workspace.asRelativePath(uri, false),
     }))
     .sort((a, b) => pathDepthCompareFn(a.relativePath, b.relativePath));
 

--- a/src/store/BackingMap.ts
+++ b/src/store/BackingMap.ts
@@ -8,7 +8,7 @@ interface BackingMapEntry {
 }
 
 const uriToKey = (uri: Uri) => {
-  return uri.path;
+  return uri.toString();
 };
 
 export class BackingMap {

--- a/src/store/findFilesByGlob.ts
+++ b/src/store/findFilesByGlob.ts
@@ -11,7 +11,9 @@ export const findFilesByGlob = async (globSpecifier: GlobSpecifier) => {
   if (filter) {
     return findResults.then((uris) => {
       logDebug(
-        `Found ${uris.length} URIs matching ${globSpecifier.files} under ${globSpecifier.directory}`,
+        `Found ${uris.length} URIs matching ${
+          globSpecifier.files
+        } under ${globSpecifier.directory.toString()}`,
       );
       return uris.filter(filter);
     });

--- a/src/story/StoryExplorerStoryFile.test.ts
+++ b/src/story/StoryExplorerStoryFile.test.ts
@@ -1,4 +1,4 @@
-import type { Uri } from 'vscode';
+import { URI } from 'vscode-uri';
 import { parseTestProjectStories } from '../../test/util/parseTestProjectStories';
 import type { ParsedStoryWithFileUri } from '../parser/parseStoriesFileByUri';
 import { StoryExplorerStoryFile } from './StoryExplorerStoryFile';
@@ -10,19 +10,17 @@ describe('StoryExplorerStoryFile', () => {
     it(`parses story file ${file}`, () => {
       const parsed: ParsedStoryWithFileUri = {
         ...parsedRaw,
-        file: {
-          path: `/mock/basedir/${file}`,
-        } as Uri,
+        file: URI.file(`/mock/basedir/${file}`),
       };
 
       const storyFile = new StoryExplorerStoryFile(parsed, [
         {
-          directory: '/mock/basedir/project/src/autoTitle',
+          directory: URI.file('/mock/basedir/project/src/autoTitle'),
           files: '**/*',
           titlePrefix: 'Auto-generated title prefix',
         },
         {
-          directory: '/mock/basedir/project/src',
+          directory: URI.file('/mock/basedir/project/src'),
           files: '**/*',
           titlePrefix: '',
         },

--- a/src/story/StoryExplorerStoryFile.ts
+++ b/src/story/StoryExplorerStoryFile.ts
@@ -38,9 +38,12 @@ export class StoryExplorerStoryFile {
   }
 
   public getTitle() {
-    const uriPath = this.getUri().path;
-    const matchingSpecifier = this.specifiers.find((specifier) =>
-      uriPath.startsWith(specifier.directory),
+    const uri = this.getUri();
+    const matchingSpecifier = this.specifiers.find(
+      (specifier) =>
+        uri.scheme === specifier.directory.scheme &&
+        uri.authority === specifier.directory.authority &&
+        uri.path.startsWith(specifier.directory.path),
     );
 
     if (!matchingSpecifier) {
@@ -52,7 +55,9 @@ export class StoryExplorerStoryFile {
     const metaTitle = this.parsed.meta.title;
     const titleSuffix = metaTitle
       ? metaTitle.split('/')
-      : getAutoTitleSuffixParts(getPartialFilePath(matchingSpecifier, uriPath));
+      : getAutoTitleSuffixParts(
+          getPartialFilePath(matchingSpecifier.directory.path, uri.path),
+        );
 
     const autoTitleParts = [...titlePrefixParts, ...titleSuffix].filter(
       Boolean,

--- a/src/story/getPartialFilePath.ts
+++ b/src/story/getPartialFilePath.ts
@@ -1,4 +1,2 @@
-import type { GlobSpecifier } from '../config/GlobSpecifier';
-
-export const getPartialFilePath = (specifier: GlobSpecifier, uriPath: string) =>
-  uriPath.slice(specifier.directory.length);
+export const getPartialFilePath = (pathPrefix: string, uriPath: string) =>
+  uriPath.slice(pathPrefix.length);

--- a/src/storybook/parseLocalConfigFile.ts
+++ b/src/storybook/parseLocalConfigFile.ts
@@ -7,7 +7,7 @@ const requireUncached = <T>(filePath: string): T => {
   return require(filePath) as T;
 };
 
-export const parseConfigFile = (configFilePath: string) => {
+export const parseLocalConfigFile = (configFilePath: string) => {
   try {
     return requireUncached<StorybookConfig>(configFilePath);
   } catch (e) {

--- a/src/util/FileWatcher.ts
+++ b/src/util/FileWatcher.ts
@@ -15,15 +15,21 @@ export type WatchListener = (
 export class FileWatcher {
   private fsWatcher?: FileSystemWatcher;
 
+  private readonly glob: GlobPattern;
+
   private readonly listenerDisposables: Disposable[] = [];
 
   public constructor(
-    private readonly glob: GlobPattern,
+    patternOrUri: GlobPattern | Uri,
     private readonly callback: WatchListener,
     ignoreCreate = false,
     ignoreChange = false,
     ignoreDelete = false,
   ) {
+    this.glob =
+      typeof patternOrUri === 'string' || 'pattern' in patternOrUri
+        ? patternOrUri
+        : patternOrUri.fsPath;
     this.init(callback, ignoreCreate, ignoreChange, ignoreDelete);
   }
 

--- a/src/util/getWorkspaceRoot.ts
+++ b/src/util/getWorkspaceRoot.ts
@@ -1,5 +1,10 @@
-import { resolve } from 'path';
 import { workspace } from 'vscode';
+import { Utils } from 'vscode-uri';
 
-export const getWorkspaceRoot = () =>
-  workspace.workspaceFolders?.[0]?.uri.path ?? resolve('/');
+export const getWorkspaceRoot = () => {
+  if (workspace.workspaceFile) {
+    return Utils.dirname(workspace.workspaceFile);
+  }
+
+  return workspace.workspaceFolders?.[0]?.uri;
+};

--- a/src/util/isVirtualUri.ts
+++ b/src/util/isVirtualUri.ts
@@ -1,0 +1,7 @@
+import type { Uri } from 'vscode';
+
+// Inspired by
+// https://code.visualstudio.com/api/extension-guides/virtual-workspaces#detect-virtual-workspaces-programmatically
+export const isVirtualUri = (uri: Uri) => {
+  return uri.scheme !== 'file';
+};

--- a/test/integration/storiesJson.test.ts
+++ b/test/integration/storiesJson.test.ts
@@ -1,12 +1,12 @@
 import { readFile } from 'fs/promises';
 import { resolve } from 'path';
 import merge from 'lodash/merge';
-import type { Uri } from 'vscode';
+import { Uri } from 'vscode';
 import { interpretStoriesConfigItem } from '../../src/config/normalizeStoriesEntry';
 import type { ParsedStoryWithFileUri } from '../../src/parser/parseStoriesFileByUri';
 import { StoryExplorerStoryFile } from '../../src/story/StoryExplorerStoryFile';
 import { getStoriesGlobs } from '../../src/storybook/getStoriesGlobs';
-import { parseConfigFile } from '../../src/storybook/parseConfig';
+import { parseLocalConfigFile } from '../../src/storybook/parseLocalConfigFile';
 import { parseTestProjectStories } from '../util/parseTestProjectStories';
 import { testBaseDir } from '../util/testBaseDir';
 
@@ -43,11 +43,14 @@ describe('stories.json', () => {
       'main.js',
     );
 
-    const mockConfig = parseConfigFile(storybookConfigPath)!;
+    const mockConfig = parseLocalConfigFile(storybookConfigPath)!;
     const storiesGlobs = await getStoriesGlobs(mockConfig.stories);
     const mockSpecifiers = await Promise.all(
       storiesGlobs.map((config) =>
-        interpretStoriesConfigItem(config, '/mock/basedir/project/.storybook'),
+        interpretStoriesConfigItem(
+          config,
+          Uri.file('/mock/basedir/project/.storybook'),
+        ),
       ),
     );
 
@@ -61,9 +64,7 @@ describe('stories.json', () => {
       .flatMap(({ file, parsedRaw }) => {
         const parsed: ParsedStoryWithFileUri = {
           ...parsedRaw,
-          file: {
-            path: `/mock/basedir/${file}`,
-          } as Uri,
+          file: Uri.file(`/mock/basedir/${file}`),
         };
 
         const storyFile = new StoryExplorerStoryFile(parsed, mockSpecifiers);


### PR DESCRIPTION
Avoid the use of the node-provided `fs` module and string path
representations in favor of VSCode-provided filesystem operations and
URIs. This enables better compatibility with features like virtual
workspaces.