### PR TITLE
fix: detect storybook configurations with non-`.js` extensions

### DIFF
--- a/src/config/ConfigManager.ts
+++ b/src/config/ConfigManager.ts
@@ -14,7 +14,7 @@ export class ConfigManager {
 
   private readonly configLocationListener =
     this.storybookConfigLocationAggregator.onDidChangeConfig((e) => {
-      setContext(storybookConfigDetectedContext, e !== undefined);
+      setContext(storybookConfigDetectedContext, e?.file !== undefined);
     });
 
   private readonly storiesGlobsConfigAggregator = new Aggregator([

--- a/src/config/StorybookConfigLocation.ts
+++ b/src/config/StorybookConfigLocation.ts
@@ -2,5 +2,5 @@ import type { Uri } from 'vscode';
 
 export interface StorybookConfigLocation {
   dir: Uri;
-  file: Uri;
+  file: Uri | undefined;
 }

--- a/src/config/configFileExtensions.ts
+++ b/src/config/configFileExtensions.ts
@@ -1,0 +1,10 @@
+export const configFileExtensions = [
+  'js',
+  'jsx',
+  'ts',
+  'tsx',
+  'cjs',
+  'mjs',
+  'cts',
+  'mts',
+];

--- a/src/config/configLocationCompareFn.test.ts
+++ b/src/config/configLocationCompareFn.test.ts
@@ -1,0 +1,76 @@
+import { URI, Utils } from 'vscode-uri';
+import {
+  ConfigLocation,
+  configLocationCompareFn,
+} from './configLocationCompareFn';
+
+const configLocationFromFakePath = (path: string): ConfigLocation => ({
+  dir: Utils.dirname(URI.file(path)),
+  file: URI.file(path),
+  relativePath: path,
+});
+
+describe('configLocationCompareFn', () => {
+  it('prioritizes shallow paths over deep paths', () => {
+    const candidates = [
+      'very/deep/path/.storybook/main.js',
+      'shallow/.storybook/main.js',
+      'deep/path/.storybook/main.js',
+    ].map(configLocationFromFakePath);
+
+    expect(candidates.sort(configLocationCompareFn).map((p) => p.relativePath))
+      .toMatchInlineSnapshot(`
+      Array [
+        "shallow/.storybook/main.js",
+        "deep/path/.storybook/main.js",
+        "very/deep/path/.storybook/main.js",
+      ]
+    `);
+  });
+
+  it('prioritizes shallow paths over deep paths regardless of extension', () => {
+    const candidates = [
+      'very/deep/path/.storybook/main.js',
+      'shallow/.storybook/main.ts',
+      'deep/path/.storybook/main.js',
+    ].map(configLocationFromFakePath);
+
+    expect(candidates.sort(configLocationCompareFn).map((p) => p.relativePath))
+      .toMatchInlineSnapshot(`
+      Array [
+        "shallow/.storybook/main.ts",
+        "deep/path/.storybook/main.js",
+        "very/deep/path/.storybook/main.js",
+      ]
+    `);
+  });
+
+  it('prioritizes extensions in order', () => {
+    const candidates = [
+      '.storybook/main.cjs',
+      '.storybook/main.cts',
+      '.storybook/main.foo',
+      '.storybook/main.js',
+      '.storybook/main.jsx',
+      '.storybook/main.mjs',
+      '.storybook/main.mts',
+      '.storybook/main.ts',
+      '.storybook/main.tsx',
+    ].map(configLocationFromFakePath);
+
+    expect(candidates.sort(configLocationCompareFn).map((p) => p.relativePath))
+      .toMatchInlineSnapshot(`
+      Array [
+        ".storybook/main.js",
+        ".storybook/main.jsx",
+        ".storybook/main.ts",
+        ".storybook/main.tsx",
+        ".storybook/main.cjs",
+        ".storybook/main.mjs",
+        ".storybook/main.cts",
+        ".storybook/main.mts",
+        ".storybook/main.foo",
+      ]
+    `);
+  });
+});

--- a/src/config/configLocationCompareFn.ts
+++ b/src/config/configLocationCompareFn.ts
@@ -1,0 +1,15 @@
+import type { Uri } from 'vscode';
+import { pathDepthCompareFn } from '../util/pathDepthCompareFn';
+import { strCompareFn } from '../util/strCompareFn';
+import { extensionCompareFn } from './extensionCompareFn';
+
+export interface ConfigLocation {
+  file: Uri;
+  dir: Uri;
+  relativePath: string;
+}
+
+export const configLocationCompareFn = (a: ConfigLocation, b: ConfigLocation) =>
+  pathDepthCompareFn(a.relativePath, b.relativePath) ||
+  extensionCompareFn(a.file.path, b.file.path) ||
+  strCompareFn(a.relativePath, b.relativePath);

--- a/src/config/extensionCompareFn.ts
+++ b/src/config/extensionCompareFn.ts
@@ -1,0 +1,28 @@
+import { extname } from 'path';
+import { configFileExtensions } from './configFileExtensions';
+
+const getExtIndex = (name: string) => {
+  const ext = extname(name);
+  const index = configFileExtensions.indexOf(ext.slice(1));
+
+  return index >= 0 ? index : undefined;
+};
+
+export const extensionCompareFn = (a: string, b: string) => {
+  const aIndex = getExtIndex(a);
+  const bIndex = getExtIndex(b);
+
+  if (aIndex === undefined) {
+    if (bIndex === undefined) {
+      return 0;
+    }
+
+    return 1;
+  }
+
+  if (bIndex === undefined) {
+    return -1;
+  }
+
+  return aIndex - bIndex;
+};

--- a/src/config/findConfigFileInDir.ts
+++ b/src/config/findConfigFileInDir.ts
@@ -1,0 +1,14 @@
+import { Uri, workspace } from 'vscode';
+import { configFileExtensions } from './configFileExtensions';
+
+export const findConfigFileInDir = async (dir: Uri) => {
+  for (const extension of configFileExtensions) {
+    try {
+      const uri = Uri.joinPath(dir, `main.${extension}`);
+      await workspace.fs.stat(uri);
+      return uri;
+    } catch {
+      // assume file doesn't exist
+    }
+  }
+};

--- a/src/config/storybookConfigLocationConfigProvider.ts
+++ b/src/config/storybookConfigLocationConfigProvider.ts
@@ -1,13 +1,13 @@
-import { Uri } from 'vscode';
 import { Utils } from 'vscode-uri';
 import { getWorkspaceRoot } from '../util/getWorkspaceRoot';
 import { SettingsConfigProvider } from './SettingsConfigProvider';
 import type { StorybookConfigLocation } from './StorybookConfigLocation';
+import { findConfigFileInDir } from './findConfigFileInDir';
 
 export const storybookConfigLocationConfigProvider = new SettingsConfigProvider<
   StorybookConfigLocation,
   unknown
->('storybookConfigDir', (rawValue: unknown) => {
+>('storybookConfigDir', async (rawValue: unknown) => {
   const sanitize = () => {
     if (typeof rawValue === 'string') {
       return rawValue;
@@ -27,13 +27,12 @@ export const storybookConfigLocationConfigProvider = new SettingsConfigProvider<
   }
 
   const dir = Utils.resolvePath(rootUri, configDir);
-  const file = Uri.joinPath(dir, 'main.js');
-  return configDir
-    ? {
-        value: {
-          dir,
-          file,
-        },
-      }
-    : undefined;
+  const file = await findConfigFileInDir(dir);
+
+  return {
+    value: {
+      dir,
+      file,
+    },
+  };
 });

--- a/src/globs/convertGlobForWorkspace.ts
+++ b/src/globs/convertGlobForWorkspace.ts
@@ -1,30 +1,6 @@
-import { join } from 'path';
-import { RelativePattern, Uri, workspace } from 'vscode';
-import { Utils } from 'vscode-uri';
 import type { GlobSpecifier } from '../config/GlobSpecifier';
+import { getRelativePatternForWorkspace } from '../util/getRelativePatternForWorkspace';
 import { convertGlob } from './convertGlob';
-
-const getRelativePatternForWorkspace = (
-  globBasePath: Uri,
-  globPattern: string | undefined,
-) => {
-  const workspaceFolder = workspace.getWorkspaceFolder(globBasePath);
-
-  const dir =
-    globPattern !== undefined ? globBasePath : Utils.dirname(globBasePath);
-  const file =
-    globPattern !== undefined ? globPattern : Utils.basename(globBasePath);
-
-  if (workspaceFolder) {
-    const pattern =
-      workspaceFolder.uri.toString() === dir.toString()
-        ? file
-        : join(workspace.asRelativePath(dir, false), file);
-    return new RelativePattern(workspaceFolder, pattern);
-  }
-
-  return new RelativePattern(dir, file);
-};
 
 export const convertGlobForWorkspace = (globSpecifier: GlobSpecifier) => {
   const { globBase, globPattern, filter, regex } = convertGlob(globSpecifier);

--- a/src/server/getStorybookBinPath.ts
+++ b/src/server/getStorybookBinPath.ts
@@ -4,6 +4,7 @@ import {
   serverInternalStorybookBinaryPathConfigSuffix,
 } from '../constants/constants';
 import { pathDepthCompareFn } from '../util/pathDepthCompareFn';
+import { strCompareFn } from '../util/strCompareFn';
 
 const getDetectedStorybookBinPath = async (): Promise<string | undefined> => {
   const matches = await workspace.findFiles(
@@ -16,7 +17,11 @@ const getDetectedStorybookBinPath = async (): Promise<string | undefined> => {
       uri,
       relativePath: workspace.asRelativePath(uri, false),
     }))
-    .sort((a, b) => pathDepthCompareFn(a.relativePath, b.relativePath));
+    .sort(
+      (a, b) =>
+        pathDepthCompareFn(a.relativePath, b.relativePath) ||
+        strCompareFn(a.relativePath, b.relativePath),
+    );
 
   return match?.uri.fsPath;
 };

--- a/src/util/getRelativePatternForWorkspace.ts
+++ b/src/util/getRelativePatternForWorkspace.ts
@@ -1,0 +1,23 @@
+import { join } from 'path';
+import { RelativePattern, Uri, workspace } from 'vscode';
+import { Utils } from 'vscode-uri';
+
+export const getRelativePatternForWorkspace = (
+  base: Uri,
+  pattern: string | undefined,
+) => {
+  const workspaceFolder = workspace.getWorkspaceFolder(base);
+
+  const dir = pattern !== undefined ? base : Utils.dirname(base);
+  const file = pattern !== undefined ? pattern : Utils.basename(base);
+
+  if (workspaceFolder) {
+    const relativePattern =
+      workspaceFolder.uri.toString() === dir.toString()
+        ? file
+        : join(workspace.asRelativePath(dir, false), file);
+    return new RelativePattern(workspaceFolder, relativePattern);
+  }
+
+  return new RelativePattern(dir, file);
+};

--- a/src/util/pathDepthCompareFn.ts
+++ b/src/util/pathDepthCompareFn.ts
@@ -1,5 +1,3 @@
-import { strCompareFn } from './strCompareFn';
-
 const getDepth = (path: string) => path.split('/').length;
 
 export const pathDepthCompareFn = (a: string, b: string): number => {
@@ -10,5 +8,5 @@ export const pathDepthCompareFn = (a: string, b: string): number => {
     return aDepth - bDepth;
   }
 
-  return strCompareFn(a, b);
+  return 0;
 };


### PR DESCRIPTION
Don't assume that a storybook config file will always be called
`main.js`. In particular, add basic support for other extensions,
including `.jsx`, `.ts`, `.cjs`, etc. This is more consistent with
Storybook's own extension support.

The contents of configuration files with non-`.js` extensions may not be
parsable, in which case automatic story discovery will not succeed. But
this will allow such files to be detected, which will (e.g.) reveal the
stories pane.

Fixes #451