### PR TITLE
fix: improve messaging when no stories found

### DIFF
--- a/package.json
+++ b/package.json
@@ -393,21 +393,30 @@
           "id": "storyExplorer.storiesView",
           "name": "Stories",
           "contextualTitle": "Story Explorer",
-          "icon": "$(bookmark)",
-          "when": "storyExplorer.storybookConfigDetected"
+          "icon": "$(bookmark)"
         }
       ]
     },
     "viewsWelcome": [
       {
         "view": "storyExplorer.storiesView",
-        "contents": "There was a problem parsing your Storybook configuration. [Check your Storybook configuration](command:storyExplorer.openStorybookConfig), or [try manually specifying your project's stories](command:storyExplorer.openStoriesGlobsSetting).",
-        "when": "storyExplorer.storybookConfigDetected && !storyExplorer.storybookConfigParsed"
+        "contents": "Looking for stories...",
+        "when": "!storyExplorer.initialLoadComplete || storyExplorer.loadingStories"
       },
       {
         "view": "storyExplorer.storiesView",
-        "contents": "No stories were found. Add a story to see it appear here, or [check your Storybook configuration](command:storyExplorer.openStorybookConfig).",
-        "when": "storyExplorer.storybookConfigParsed"
+        "contents": "No Storybook configuration or stories were found. Try manually specifying your project's [configuration directory](command:storyExplorer.openStorybookConfigDirSetting) or [stories](command:storyExplorer.openStoriesGlobsSetting).",
+        "when": "storyExplorer.initialLoadComplete && !storyExplorer.loadingStories && !storyExplorer.storybookConfigDetected"
+      },
+      {
+        "view": "storyExplorer.storiesView",
+        "contents": "There was a problem parsing your Storybook configuration. [Check your Storybook configuration](command:storyExplorer.openStorybookConfig), or [try manually specifying your project's stories](command:storyExplorer.openStoriesGlobsSetting).",
+        "when": "storyExplorer.initialLoadComplete && !storyExplorer.loadingStories && storyExplorer.storybookConfigDetected && storyExplorer.storybookConfigParseFailed"
+      },
+      {
+        "view": "storyExplorer.storiesView",
+        "contents": "No stories were found. Add a story to see it appear here, or [check your Storybook configuration](command:storyExplorer.openStorybookConfig), or [try manually specifying your project's stories](command:storyExplorer.openStoriesGlobsSetting).",
+        "when": "storyExplorer.initialLoadComplete && !storyExplorer.loadingStories && storyExplorer.storybookConfigDetected && !storyExplorer.storybookConfigParseFailed"
       }
     ]
   },

--- a/src/commands/openStorybookConfigDirSetting.ts
+++ b/src/commands/openStorybookConfigDirSetting.ts
@@ -1,0 +1,11 @@
+import { storybookConfigDirConfig } from '../constants/constants';
+import { logError } from '../log/log';
+import { openWorkspaceSetting } from '../util/openWorkspaceSetting';
+
+export const openStorybookConfigDirSetting = () => async () => {
+  try {
+    await openWorkspaceSetting(storybookConfigDirConfig);
+  } catch (e) {
+    logError('Failed to open Storybook config directory workspace setting', e);
+  }
+};

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -2,12 +2,16 @@ import { makeFullConfigName } from '../util/makeFullConfigName';
 
 export const extensionName = 'Story Explorer';
 
+export const initialLoadCompleteContext = 'storyExplorer.initialLoadComplete';
 export const internalServerRunningContext =
   'storyExplorer.internalServerRunning';
+export const loadingStoriesContext = 'storyExplorer.loadingStories';
 export const storybookConfigDetectedContext =
   'storyExplorer.storybookConfigDetected';
 export const storybookConfigParsedContext =
   'storyExplorer.storybookConfigParsed';
+export const storybookConfigParseFailedContext =
+  'storyExplorer.storybookConfigParseFailed';
 export const storybookPreviewFocusedContext =
   'storyExplorer.storybookPreviewFocused';
 export const storybookWebviewsOpenContext =
@@ -21,6 +25,8 @@ export const openPreviewCommand = 'storyExplorer.openPreview';
 export const openPreviewInBrowserCommand = 'storyExplorer.openPreviewInBrowser';
 export const openPreviewToSideCommand = 'storyExplorer.openPreviewToSide';
 export const openStorybookConfigCommand = 'storyExplorer.openStorybookConfig';
+export const openStorybookConfigDirSettingCommand =
+  'storyExplorer.openStorybookConfigDirSetting';
 export const openStoriesGlobsSettingCommand =
   'storyExplorer.openStoriesGlobsSetting';
 export const openStorybookInBrowserCommand =

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { openPreview } from './commands/openPreview';
 import { openPreviewInBrowser } from './commands/openPreviewInBrowser';
 import { openStoriesGlobsSetting } from './commands/openStoriesGlobsSetting';
 import { openStorybookConfig } from './commands/openStorybookConfig';
+import { openStorybookConfigDirSetting } from './commands/openStorybookConfigDirSetting';
 import { openStorybookInBrowser } from './commands/openStorybookInBrowser';
 import { openStorybookUrlSetting } from './commands/openStorybookUrlSetting';
 import { refreshAllWebviews } from './commands/refreshAllWebviews';
@@ -26,6 +27,7 @@ import {
   openPreviewToSideCommand,
   openStoriesGlobsSettingCommand,
   openStorybookConfigCommand,
+  openStorybookConfigDirSettingCommand,
   openStorybookInBrowserCommand,
   openStorybookUrlSettingCommand,
   refreshAllWebviewsCommand,
@@ -105,6 +107,10 @@ export const activate = async (context: ExtensionContext) => {
     registerCommand(
       openPreviewInBrowserCommand,
       openPreviewInBrowser(webviewManager, storyStore, serverManager),
+    );
+    registerCommand(
+      openStorybookConfigDirSettingCommand,
+      openStorybookConfigDirSetting(),
     );
     registerCommand(openStoriesGlobsSettingCommand, openStoriesGlobsSetting());
     registerCommand(openStorybookUrlSettingCommand, openStorybookUrlSetting());


### PR DESCRIPTION
Always show the stories view, even if a configuration cannot be
detected. This makes it clearer that the extension has loaded and
provides an opportunity to provide a hint to the user about what may be
wrong and how to resolve it.

Avoid suggesting that there was a problem parsing a Storybook
configuration unless an actual problem was encountered; previously, this
message could appear while scanning for stories, even if there was no
problem loading the configuration.