### PR TITLE
fix: ignore default excludes when searching for start-storybook

### DIFF
--- a/src/server/getStorybookBinPath.ts
+++ b/src/server/getStorybookBinPath.ts
@@ -9,7 +9,7 @@ import { strCompareFn } from '../util/strCompareFn';
 const getDetectedStorybookBinPath = async (): Promise<string | undefined> => {
   const matches = await workspace.findFiles(
     '**/node_modules/.bin/start-storybook',
-    undefined,
+    null,
   );
 
   const [match] = matches


### PR DESCRIPTION
The `start-storybook` script is expected to be located within
`node_modules`, which may be among the user's exclusions. Specify `null`
instead of `undefined` as the `exclude` parameter for
`workspace.findFiles`, which causes default and user exclusions not to
be used.