### PR TITLE
fix: improve logging of objects

### DIFF
--- a/src/log/log.ts
+++ b/src/log/log.ts
@@ -60,6 +60,14 @@ const stringify = (item: unknown) => {
     }`;
   }
 
+  if (typeof item === 'object' && String(item) === '[object Object]') {
+    try {
+      return JSON.stringify(item);
+    } catch {
+      // fall through
+    }
+  }
+
   return item;
 };
 


### PR DESCRIPTION
Avoid logging objects as `[object Object]` in the output channel;
instead, try logging such objects as stringified JSON. Continue logging
objects with custom toString representations as they are.