### PR TITLE
fix: improve start-storybook script detection

### DIFF
--- a/src/server/StorybookServer.ts
+++ b/src/server/StorybookServer.ts
@@ -161,8 +161,8 @@ export class StorybookServer {
   }
 
   private async createTask() {
-    const binPath = await getStorybookBinPath();
     const configDir = this.configManager.getConfigDir();
+    const binPath = await getStorybookBinPath(configDir);
     const cwd = configDir
       ? workspace.getWorkspaceFolder(configDir)?.uri
       : undefined;

--- a/src/util/tryStat.ts
+++ b/src/util/tryStat.ts
@@ -1,0 +1,9 @@
+import { Uri, workspace } from 'vscode';
+
+export const tryStat = async (uri: Uri) => {
+  try {
+    return await workspace.fs.stat(uri);
+  } catch (e) {
+    return undefined;
+  }
+};


### PR DESCRIPTION
Searching the workspace via `workspace.findFiles` is subject to the
user's `search.followSymlinks` setting, which will cause the search to
fail on platforms that use symlinks in the `.bin` directory.

Instead of searching the entire workspace, use node module resolution to
check specific locations based on the location of the Storybook
configuration directory, if available. If this check fails or the
configuration directory itself cannot be located, then fall back to the
`findFiles`-based search.

Fixes #460