### PR TITLE
fix: default `server.internal.enabled` value should be boolean

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
         "storyExplorer.server.internal.enabled": {
           "scope": "window",
           "markdownDescription": "Controls whether to enable the internal Storybook development server. When unchecked, you will have to run the server externally.",
-          "default": "true",
+          "default": true,
           "type": "boolean"
         },
         "storyExplorer.server.internal.behavior": {


### PR DESCRIPTION
`storyExplorer.server.internal.enabled` should default to boolean
`true`, but it was defaulting to the string `"true"` instead. Although
this worked at runtime, it caused VS Code to suggest the invalid
`"true"` default value when manually editing `settings.json`.