### PR TITLE
fix: use kind name as webview title for docs

### DIFF
--- a/src/story/StoryExplorerStory.ts
+++ b/src/story/StoryExplorerStory.ts
@@ -31,11 +31,9 @@ export class StoryExplorerStory {
   public readonly isDocs: boolean;
 
   private constructor(
-    private readonly story: Pick<
-      StoryExplorerStory,
-      'id' | 'name' | 'location' | 'isDocs'
-    >,
+    story: Pick<StoryExplorerStory, 'id' | 'name' | 'location' | 'isDocs'>,
     private readonly storyFile: StoryExplorerStoryFile,
+    public readonly label: string,
   ) {
     this.id = story.id;
     this.name = story.name;
@@ -51,9 +49,9 @@ export class StoryExplorerStory {
       return undefined;
     }
 
-    const [nameFromTitle = ''] = splitKind(title).slice(-1);
+    const [label = ''] = splitKind(title).slice(-1);
 
-    const name = storyFile.isDocsOnly() ? DOCS_ONLY_STORY_NAME : nameFromTitle;
+    const name = storyFile.isDocsOnly() ? DOCS_ONLY_STORY_NAME : label;
 
     return new StoryExplorerStory(
       {
@@ -63,6 +61,7 @@ export class StoryExplorerStory {
         isDocs: true,
       },
       storyFile,
+      label,
     );
   }
 
@@ -84,6 +83,7 @@ export class StoryExplorerStory {
         isDocs: false,
       },
       storyFile,
+      name,
     );
   }
 
@@ -100,7 +100,7 @@ export class StoryExplorerStory {
   }
 
   public getOpenCommand(viewColumn?: ViewColumn) {
-    const location = this.story.location;
+    const location = this.location;
 
     return createOpenInEditorCommand(this.storyFile.getUri(), {
       selection: location

--- a/src/webview/StoryWebview.ts
+++ b/src/webview/StoryWebview.ts
@@ -214,7 +214,7 @@ export class StoryWebview {
       this.serverManager.ensureServerHealthy(),
     );
 
-    this.panel.title = this.story.name;
+    this.panel.title = this.story.label;
 
     this.panel.iconPath = {
       dark: getIconPath(this.story.getIconName(), this.context, 'dark'),


### PR DESCRIPTION
Use the last segment of the kind name for the webview title when showing
a docs-only story, instead of the internal name "Page".