### PR TITLE
fix: always determine config file location

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import type { Subscription } from 'rxjs';
 import type { ExtensionContext } from 'vscode';
 
 import { commands, Disposable } from 'vscode';
@@ -19,6 +20,7 @@ import { startStorybookServer } from './commands/startStorybookServer';
 import { stopStorybookServer } from './commands/stopStorybookServer';
 import { IdCompletionManager } from './completion/IdCompletionManager';
 import { TitleCompletionManager } from './completion/TitleCompletionManager';
+import { storybookConfigLocation } from './config/storybookConfigLocation';
 import {
   goToStorySourceCommand,
   openOutputChannelCommand,
@@ -50,6 +52,14 @@ export const activate = async (context: ExtensionContext) => {
     return item;
   };
 
+  const addObservableSubscription = (subscription: Subscription) => {
+    return {
+      dispose: () => {
+        subscription.unsubscribe();
+      },
+    };
+  };
+
   addSubscription(initLogger(context.extensionMode));
 
   logInfo('Starting extension activation');
@@ -79,6 +89,8 @@ export const activate = async (context: ExtensionContext) => {
         proxyManager,
       ),
     );
+
+    addObservableSubscription(storybookConfigLocation.subscribe());
 
     addSubscription(CodeLensManager.init(storyStore));
     addSubscription(TitleCompletionManager.init(storyStore));


### PR DESCRIPTION
The location of the Storybook config always needs to be known in order to enable certain commands, like opening the configuration file or attempting to start a Storybook server. To ensure these commands are properly enabled, always subscribe to the configuration location.

This addresses an issue where the configuration location would never be determined if all of the settings (i.e., stories globs) ordinarily dependent on the configuration location were overridden via VS Code settings, thus causing those commands to never become enabled.