### PR TITLE
fix: avoid relaunching running tasks

### DIFF
--- a/src/server/createProcessTask.ts
+++ b/src/server/createProcessTask.ts
@@ -1,4 +1,4 @@
-import { ProcessExecution, Task, TaskScope } from 'vscode';
+import { ProcessExecution, Task, TaskRevealKind, TaskScope } from 'vscode';
 import type { EnvironmentVariables } from './EnvironmentVariables';
 
 export const createProcessTask = (
@@ -6,8 +6,8 @@ export const createProcessTask = (
   args: string[],
   cwdPath: string | undefined,
   injectedEnv: EnvironmentVariables,
-) =>
-  new Task(
+) => {
+  const task = new Task(
     { type: 'story-explorer' },
     TaskScope.Workspace,
     'Storybook Server',
@@ -17,3 +17,12 @@ export const createProcessTask = (
       env: injectedEnv,
     }),
   );
+
+  task.isBackground = true;
+  task.detail = 'Storybook Development Server';
+  task.presentationOptions = {
+    reveal: TaskRevealKind.Silent,
+  };
+
+  return task;
+};

--- a/src/server/getOrCreateTask.ts
+++ b/src/server/getOrCreateTask.ts
@@ -1,6 +1,6 @@
 import { isDeepStrictEqual } from 'util';
 import { firstValueFrom } from 'rxjs';
-import { TaskRevealKind, tasks } from 'vscode';
+import { tasks } from 'vscode';
 import { storybookConfigLocation } from '../config/storybookConfigLocation';
 import { serverInternalEnvironmentVariablesConfigSuffix } from '../constants/constants';
 import { logDebug } from '../log/log';
@@ -120,12 +120,6 @@ export const getOrCreateTask = async () => {
   if (!task) {
     return undefined;
   }
-
-  task.isBackground = true;
-  task.detail = 'Storybook Development Server';
-  task.presentationOptions = {
-    reveal: TaskRevealKind.Silent,
-  };
 
   const existingExecution = tasks.taskExecutions.find(
     (execution) =>


### PR DESCRIPTION
Mutating tasks caused them to appear to be different than existing executions, causing them to be relaunched even when an equivalent task had already been started. Avoid mutating tasks that are not created internally (as opposed to fetched from existing tasks) so that such comparisons work as expected.