### PR TITLE
filter only localhost ports

### DIFF
--- a/src/server/getPort.ts
+++ b/src/server/getPort.ts
@@ -19,7 +19,7 @@ const getPortNetstat = (pids: number[]) =>
         },
       },
       (data) => {
-        if (data.local.port && pids.includes(data.pid)) {
+        if (data.local.port && pids.includes(data.pid) && data.local.address == '127.0.0.1') {
           resolve(data.local.port);
         }
       },


### PR DESCRIPTION
Netstat finds different ports for me but only one of them is localhost
so I added an additional condition

![image](https://user-images.githubusercontent.com/17424528/220684453-e37231b5-1d9e-4120-832e-80fdbaa31c3e.png)
