### PR TITLE
fix: add skeleton MDX language contribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -462,6 +462,17 @@
         }
       }
     },
+    "languages": [
+      {
+        "id": "mdx",
+        "aliases": [
+          "MDX"
+        ],
+        "extensions": [
+          ".mdx"
+        ]
+      }
+    ],
     "menus": {
       "commandPalette": [
         {


### PR DESCRIPTION
In order for MDX-specific features to work, the MDX language must be registered. While other extensions handle this, if they are not present, MDX-specific features won't work. Provide a basic skeleton registration that enables MDX-specific features even if no other MDX-aware extensions are installed.