### PR TITLE
fix: remove non-functional npm args setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,6 @@ The method to use to launch the Storybook development server.
 
 - `custom`: Run a custom command
 
-### `storyExplorer.server.internal.npm.args`
-
-Array of command line arguments to pass to the npm script when launching a development server. Only used when [`storyExplorer.server.internal.launchStrategy`](#storyexplorerserverinternallaunchstrategy) is set to `storybook` or `detect`.
-
 ### `storyExplorer.server.internal.npm.dir`
 
 Optional path to the directory containing the `package.json` file with the npm script to use. If your workspace contains multiple `package.json` files with the same script name, you can set this to specify which one to use. Only used when [`storyExplorer.server.internal.launchStrategy`](#storyexplorerserverinternallaunchstrategy) is set to `npm` or `detect`.

--- a/package.json
+++ b/package.json
@@ -312,17 +312,6 @@
           ],
           "default": "storybook"
         },
-        "storyExplorer.server.internal.npm.args": {
-          "scope": "window",
-          "markdownDescription": "Array of command line arguments to pass to the npm script when launching a development server. Only used when `#storyExplorer.server.internal.launchStrategy#` is set to `storybook` or `detect`.",
-          "type": "array",
-          "items": {
-            "type": [
-              "string",
-              "number"
-            ]
-          }
-        },
         "storyExplorer.server.internal.task.label": {
           "scope": "window",
           "markdownDescription": "Label of the task to run to launch the Storybook development server. Only used when `#storyExplorer.server.internal.launchStrategy#` is set to `task` or `detect`.",

--- a/src/server/taskCreators/npmScript.ts
+++ b/src/server/taskCreators/npmScript.ts
@@ -6,7 +6,6 @@ import { isNonEmptyString } from '../../util/guards/isNonEmptyString';
 import { isTruthy } from '../../util/guards/isTruthy';
 import type { TaskCreatorOptions } from '../TaskCreatorOptions';
 import { fetchVsCodeTask } from '../fetchVsCodeTask';
-import { getSanitizedArgs } from '../getSanitizedArgs';
 
 interface NpmTaskDefinition extends TaskDefinition {
   readonly type: 'npm';
@@ -33,7 +32,7 @@ export const tryGetNpmScriptTask = async (taskOptions: TaskCreatorOptions) => {
 
   const packageDir = readConfiguration('server.internal.npm.dir');
 
-  const npmTask = await fetchVsCodeTask(taskOptions, {
+  return await fetchVsCodeTask(taskOptions, {
     type: 'npm',
     filterFn: (task) => {
       const definition = task.definition as NpmTaskDefinition;
@@ -66,21 +65,4 @@ export const tryGetNpmScriptTask = async (taskOptions: TaskCreatorOptions) => {
       return true;
     },
   });
-
-  if (!npmTask) {
-    return undefined;
-  }
-
-  const args = getSanitizedArgs(readConfiguration('server.internal.npm.args'));
-
-  if (
-    args &&
-    args.length > 0 &&
-    hasProperty('args')(npmTask.execution) &&
-    Array.isArray(npmTask.execution.args)
-  ) {
-    npmTask.execution.args.push('--', ...args);
-  }
-
-  return npmTask;
 };


### PR DESCRIPTION
VS Code doesn't actually support setting args for `npm` script invocations, so the corresponding setting did not do anything. Remove it to avoid confusion.