### PR TITLE
chore: switch tsconfig lib to ES2020

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,7 @@
     "target": "esnext",
     "outDir": "out",
     "emitDeclarationOnly": true,
-    "lib": ["ES2019"],
+    "lib": ["ES2020"],
     "sourceMap": true,
     "rootDir": ".",
     "strict": true,


### PR DESCRIPTION
The minimum VS Code target uses Node 14, which is covered by ES2020.