### PR TITLE
fix: avoid confusing outgoing ports with open ports

### DIFF
--- a/src/server/parseLsOfForPorts.test.ts
+++ b/src/server/parseLsOfForPorts.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { parseLsOfForPorts } from './parseLsOfForPorts';
+
+describe('parseLsOfForPorts', () => {
+  it('returns open port when present in output', () => {
+    const mockOutput = `p28195
+f157
+n*:51142
+f158
+n192.168.12.34:51147->127.9.9.9:443`;
+
+    expect(parseLsOfForPorts(mockOutput)).toStrictEqual([51142]);
+  });
+
+  it('returns multiple open ports when present in output', () => {
+    const mockOutput = `p28195
+f157
+n*:51142
+f158
+n192.168.12.34:51147->127.9.9.9:443
+f159
+n127.0.0.1:51149`;
+
+    expect(parseLsOfForPorts(mockOutput)).toStrictEqual([51142, 51149]);
+  });
+
+  it('returns empty array when no ports are open', () => {
+    const mockOutput = `p28195
+f158
+n192.168.12.34:51147->127.9.9.9:443`;
+
+    expect(parseLsOfForPorts(mockOutput)).toStrictEqual([]);
+  });
+});

--- a/src/server/parseLsOfForPorts.ts
+++ b/src/server/parseLsOfForPorts.ts
@@ -1,0 +1,11 @@
+import { isDefined } from '../util/guards/isDefined';
+
+export const parseLsOfForPorts = (stdout: string) => {
+  const lines = stdout.trim();
+  const matches = [...lines.matchAll(/^n[^(?:->)]+:([0-9]+)$/gm)];
+
+  return matches
+    .map(([, port]) => port)
+    .filter(isDefined)
+    .map((p) => parseInt(p));
+};


### PR DESCRIPTION
Sometimes, ports used as the destination for outgoing connections were erroneously being treated as locally open ports, causing connecting to the Storybook dev server to fail.

This could be readily reproduced by trying to launch Storybook without CI mode enabled and with the requested port already in use, in which case no local port was available, but an outbound request from a watched process caused port 443 to be returned incorrectly.