### PR TITLE
fix: limit workaround for CLI env args

### DIFF
--- a/src/server/taskCreators/storybookCli.ts
+++ b/src/server/taskCreators/storybookCli.ts
@@ -1,5 +1,5 @@
 import { firstValueFrom } from 'rxjs';
-import { gte } from 'semver';
+import { gte, lt } from 'semver';
 import { Uri, workspace } from 'vscode';
 import { readConfiguration } from '../../util/getConfiguration';
 import { getInstalledPackageVersion } from '../../util/getInstalledPackageVersion';
@@ -39,8 +39,10 @@ const getStorybookCliLocation = async (configDir: Uri | undefined) => {
 };
 
 // https://github.com/storybookjs/storybook/issues/21055
-const shouldInjectEnvFlags = async () =>
-  gte(await firstValueFrom(storybookVersion), VERSION_7_x_ALPHA);
+const shouldInjectEnvFlags = async () => {
+  const version = await firstValueFrom(storybookVersion);
+  return gte(version, VERSION_7_x_ALPHA) && lt(version, '7.0.0-rc.7');
+};
 
 const getAdjustedArgs = (args: string[], configDirPath: string | undefined) => {
   return [


### PR DESCRIPTION
The upstream bug that was worked around by
6eee046e2cc604a44c76ff28ed3795390ee69966 has been fixed, so the workaround is no longer necessary when using sufficiently recent CLI versions. Add an upper bound to the version check that gates the workaround to reflect this.