### PR TITLE
chore: enforce consistent type imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
     "prettier"
   ],
   "rules": {
+    "@typescript-eslint/consistent-type-imports": "error",
     "@typescript-eslint/explicit-member-accessibility": "error",
     "@typescript-eslint/member-ordering": "warn",
     "@typescript-eslint/no-empty-function": [

--- a/src/codelens/CodeLensManager.ts
+++ b/src/codelens/CodeLensManager.ts
@@ -1,4 +1,5 @@
-import { Disposable, languages } from 'vscode';
+import type { Disposable } from 'vscode';
+import { languages } from 'vscode';
 import {
   codeLensDocsEnabledConfigSuffix,
   codeLensStoriesEnabledConfigSuffix,

--- a/src/codelens/StoryCodeLensProvider.ts
+++ b/src/codelens/StoryCodeLensProvider.ts
@@ -1,11 +1,6 @@
 import { firstValueFrom } from 'rxjs';
-import {
-  CodeLens,
-  CodeLensProvider,
-  EventEmitter,
-  Range,
-  TextDocument,
-} from 'vscode';
+import type { CodeLensProvider, TextDocument } from 'vscode';
+import { CodeLens, EventEmitter, Range } from 'vscode';
 import { autodocsConfig } from '../config/autodocs';
 import { storiesGlobs } from '../config/storiesGlobs';
 import { supportLooseStoryNameSemantics } from '../config/supportLegacyStoryNameProperty';

--- a/src/completion/IdCompletionManager.ts
+++ b/src/completion/IdCompletionManager.ts
@@ -1,4 +1,5 @@
-import { Disposable, languages } from 'vscode';
+import type { Disposable } from 'vscode';
+import { languages } from 'vscode';
 import { suggestStoryIdConfigSuffix } from '../constants/constants';
 import type { StoryStore } from '../store/StoryStore';
 import { SettingsWatcher } from '../util/SettingsWatcher';

--- a/src/completion/MdxStoryIdCompletionProvider.ts
+++ b/src/completion/MdxStoryIdCompletionProvider.ts
@@ -1,10 +1,10 @@
-import {
+import type {
   CompletionItemProvider,
   CompletionList,
   Position,
   TextDocument,
-  workspace,
 } from 'vscode';
+import { workspace } from 'vscode';
 import type { StoryStore } from '../store/StoryStore';
 import type { SettingsWatcher } from '../util/SettingsWatcher';
 import { TextCompletionItem } from './TextCompletionItem';

--- a/src/completion/TitleCompletionManager.ts
+++ b/src/completion/TitleCompletionManager.ts
@@ -1,4 +1,5 @@
-import { Disposable, languages } from 'vscode';
+import type { Disposable } from 'vscode';
+import { languages } from 'vscode';
 import { suggestTitleConfigSuffix } from '../constants/constants';
 import type { StoryStore } from '../store/StoryStore';
 import { SettingsWatcher } from '../util/SettingsWatcher';

--- a/src/completion/getRangeForCompletion.ts
+++ b/src/completion/getRangeForCompletion.ts
@@ -1,4 +1,5 @@
-import { Position, Range, TextDocument } from 'vscode';
+import type { Position, TextDocument } from 'vscode';
+import { Range } from 'vscode';
 import { logError } from '../log/log';
 import type { StoryStore } from '../store/StoryStore';
 

--- a/src/config/__mocks__/autodocs.ts
+++ b/src/config/__mocks__/autodocs.ts
@@ -1,9 +1,13 @@
 import { BehaviorSubject, defer } from 'rxjs';
-import type { AutodocsConfig } from '../autodocs';
+import type {
+  AutodocsConfig,
+  autodocsConfig as autodocsConfigActual,
+} from '../autodocs';
 
 export const mockAutodocsSubject = new BehaviorSubject<
   AutodocsConfig | undefined
 >(undefined);
 
-export const autodocsConfig: typeof import('../autodocs').autodocsConfig =
-  defer(() => mockAutodocsSubject);
+export const autodocsConfig: typeof autodocsConfigActual = defer(
+  () => mockAutodocsSubject,
+);

--- a/src/config/autodocs.ts
+++ b/src/config/autodocs.ts
@@ -1,4 +1,5 @@
-import { combineLatest, map, Observable, of, switchMap } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { combineLatest, map, of, switchMap } from 'rxjs';
 import { isNonEmptyString } from '../util/guards/isNonEmptyString';
 import { deferAndShare } from '../util/rxjs/deferAndShare';
 import { distinctUntilNotStrictEqual } from '../util/rxjs/distinctUntilNotStrictEqual';

--- a/src/config/configLocationCompareFn.test.ts
+++ b/src/config/configLocationCompareFn.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { URI, Utils } from 'vscode-uri';
-import {
-  ConfigLocation,
-  configLocationCompareFn,
-} from './configLocationCompareFn';
+import type { ConfigLocation } from './configLocationCompareFn';
+import { configLocationCompareFn } from './configLocationCompareFn';
 
 const configLocationFromFakePath = (path: string): ConfigLocation => ({
   dir: Utils.dirname(URI.file(path)),

--- a/src/config/interpretStoriesConfigItem.ts
+++ b/src/config/interpretStoriesConfigItem.ts
@@ -1,6 +1,7 @@
 import { basename, dirname } from 'path';
 import { scan } from 'picomatch';
-import { FileType, Uri, workspace } from 'vscode';
+import type { Uri } from 'vscode';
+import { FileType, workspace } from 'vscode';
 import { Utils } from 'vscode-uri';
 import type { StoriesConfigItem } from '../storybook/StorybookConfig';
 import type { GlobSpecifier } from './GlobSpecifier';

--- a/src/config/storybookConfigLocation.ts
+++ b/src/config/storybookConfigLocation.ts
@@ -1,3 +1,4 @@
+import type { Observable } from 'rxjs';
 import {
   combineLatestWith,
   defer,
@@ -7,7 +8,6 @@ import {
   ignoreElements,
   map,
   merge,
-  Observable,
   scan,
   shareReplay,
   startWith,
@@ -16,7 +16,8 @@ import {
   tap,
   window,
 } from 'rxjs';
-import { GlobPattern, RelativePattern, Uri, workspace } from 'vscode';
+import type { GlobPattern, Uri } from 'vscode';
+import { RelativePattern, workspace } from 'vscode';
 import { Utils } from 'vscode-uri';
 import { storybookConfigDetectedContext } from '../constants/constants';
 import { storybookConfigDirConfigSuffix } from '../constants/constants';
@@ -28,10 +29,8 @@ import { watchFileDeletion } from '../util/rxjs/watchFileDeletion';
 import { setContext } from '../util/setContext';
 import { workspaceRoot } from '../util/workspaceRoot';
 import { configFileExtensions } from './configFileExtensions';
-import {
-  ConfigLocation,
-  configLocationCompareFn,
-} from './configLocationCompareFn';
+import type { ConfigLocation } from './configLocationCompareFn';
+import { configLocationCompareFn } from './configLocationCompareFn';
 
 export interface StorybookConfigLocation {
   dir: Uri;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import type { Subscription } from 'rxjs';
-import type { ExtensionContext } from 'vscode';
+import type { Disposable, ExtensionContext } from 'vscode';
 
-import { commands, Disposable } from 'vscode';
+import { commands } from 'vscode';
 import { CodeLensManager } from './codelens/CodeLensManager';
 import { goToStorySource } from './commands/goToStorySource';
 import { openOutputChannel } from './commands/openOutputChannel';

--- a/src/log/log.ts
+++ b/src/log/log.ts
@@ -1,4 +1,5 @@
-import { Disposable, ExtensionMode, OutputChannel, window } from 'vscode';
+import type { Disposable, OutputChannel } from 'vscode';
+import { ExtensionMode, window } from 'vscode';
 import { extensionName, logLevelConfigSuffix } from '../constants/constants';
 import { SettingsWatcher } from '../util/SettingsWatcher';
 

--- a/src/parser/csf/csf.ts
+++ b/src/parser/csf/csf.ts
@@ -5,7 +5,8 @@ import { isNonEmptyString } from '../../util/guards/isNonEmptyString';
 import type { RawParsedStoryFile } from '../RawParsedStoryFile';
 import { sanitizeMetaObject } from '../sanitizeMetaObject';
 import { isStoryDescriptor } from './isStoryDescriptor';
-import { parseFromContents, RawStory } from './parseFromContents';
+import type { RawStory } from './parseFromContents';
+import { parseFromContents } from './parseFromContents';
 
 export interface CsfParseOptions {
   /**

--- a/src/parser/csf/parseFromContents.ts
+++ b/src/parser/csf/parseFromContents.ts
@@ -1,18 +1,20 @@
 import { parse } from '@babel/parser';
 import traverse from '@babel/traverse';
 import type { NodePath } from '@babel/traverse';
-import {
+import type {
   ClassDeclaration,
   Expression,
   FunctionDeclaration,
   Identifier,
-  isExportSpecifier,
-  isIdentifier,
-  isTSSatisfiesExpression,
   ObjectExpression,
   SourceLocation,
   TSDeclareFunction,
   VariableDeclarator,
+} from '@babel/types';
+import {
+  isExportSpecifier,
+  isIdentifier,
+  isTSSatisfiesExpression,
 } from '@babel/types';
 import type { Location } from '../../types/Location';
 import type { PropertyInfo } from '../PropertyInfo';

--- a/src/parser/mdx/parseFromContents.ts
+++ b/src/parser/mdx/parseFromContents.ts
@@ -1,11 +1,8 @@
 import { parse } from '@babel/parser';
-import traverse, { NodePath } from '@babel/traverse';
-import {
-  ImportDeclaration,
-  isJSXIdentifier,
-  JSXAttribute,
-  JSXElement,
-} from '@babel/types';
+import type { NodePath } from '@babel/traverse';
+import traverse from '@babel/traverse';
+import type { ImportDeclaration, JSXAttribute, JSXElement } from '@babel/types';
+import { isJSXIdentifier } from '@babel/types';
 import type { Location } from '../../types/Location';
 import type { PropertyInfo } from '../PropertyInfo';
 import { sourceLocationToLocation } from '../sourceLocationToLocation';

--- a/src/parser/parseStoriesFile.ts
+++ b/src/parser/parseStoriesFile.ts
@@ -1,4 +1,5 @@
-import { CsfParseOptions, tryParseCsf } from './csf/csf';
+import type { CsfParseOptions } from './csf/csf';
+import { tryParseCsf } from './csf/csf';
 import { tryParseMdx } from './mdx/mdx';
 
 const csfParser = { parser: tryParseCsf, type: 'csf' } as const;

--- a/src/proxy/ProxyServer.ts
+++ b/src/proxy/ProxyServer.ts
@@ -1,4 +1,5 @@
-import { createServer, Server, ServerResponse } from 'http';
+import type { Server, ServerResponse } from 'http';
+import { createServer } from 'http';
 import type { AddressInfo } from 'net';
 import * as httpProxy from 'http-proxy';
 import { Uri } from 'vscode';

--- a/src/server/StorybookServer.ts
+++ b/src/server/StorybookServer.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage } from 'http';
 import type { Observable } from 'rxjs';
-import { ProgressLocation, TaskExecution, window } from 'vscode';
+import type { TaskExecution } from 'vscode';
+import { ProgressLocation, window } from 'vscode';
 import { internalServerRunningContext } from '../constants/constants';
 import { logDebug, logError, logInfo } from '../log/log';
 import { Cacheable } from '../util/Cacheable';

--- a/src/server/TaskExecutor.ts
+++ b/src/server/TaskExecutor.ts
@@ -1,13 +1,13 @@
-import { firstValueFrom, Observable } from 'rxjs';
-import {
+import type { Observable } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
+import type {
   CancellationToken,
   Task,
   TaskExecution,
   TaskProcessEndEvent,
   TaskProcessStartEvent,
-  tasks,
-  window,
 } from 'vscode';
+import { tasks, window } from 'vscode';
 import { logDebug, logError } from '../log/log';
 import { openWorkspaceSetting } from '../util/openWorkspaceSetting';
 import { TaskProcessListener } from './TaskProcessListener';

--- a/src/server/TaskProcessListener.ts
+++ b/src/server/TaskProcessListener.ts
@@ -1,10 +1,10 @@
-import {
+import type {
   Disposable,
   TaskExecution,
   TaskProcessEndEvent,
   TaskProcessStartEvent,
-  tasks,
 } from 'vscode';
+import { tasks } from 'vscode';
 
 export class TaskProcessListener {
   private startListener: Disposable | undefined;

--- a/src/server/fetch.ts
+++ b/src/server/fetch.ts
@@ -1,5 +1,7 @@
-import { IncomingMessage, request } from 'http';
-import { CancellationError, CancellationToken, Disposable } from 'vscode';
+import type { IncomingMessage } from 'http';
+import { request } from 'http';
+import type { CancellationToken, Disposable } from 'vscode';
+import { CancellationError } from 'vscode';
 
 export class TimeoutError extends Error {}
 

--- a/src/server/fetchVsCodeTask.ts
+++ b/src/server/fetchVsCodeTask.ts
@@ -1,4 +1,5 @@
-import { Task, tasks } from 'vscode';
+import type { Task } from 'vscode';
+import { tasks } from 'vscode';
 import type { TaskCreatorOptions } from './TaskCreatorOptions';
 
 export const fetchVsCodeTask = async (

--- a/src/server/getBinPath.ts
+++ b/src/server/getBinPath.ts
@@ -1,5 +1,6 @@
 import { platform } from 'process';
-import { Uri, workspace } from 'vscode';
+import type { Uri } from 'vscode';
+import { workspace } from 'vscode';
 import { Utils } from 'vscode-uri';
 import { logDebug } from '../log/log';
 import type { ConfigurationSuffix } from '../types/ConfigurationSuffix';

--- a/src/server/processExecutions.ts
+++ b/src/server/processExecutions.ts
@@ -1,5 +1,6 @@
 import { merge, scan } from 'rxjs';
-import { TaskExecution, tasks } from 'vscode';
+import type { TaskExecution } from 'vscode';
+import { tasks } from 'vscode';
 import { hasProperty } from '../util/guards/hasProperty';
 import { deferAndShare } from '../util/rxjs/deferAndShare';
 import { fromVsCodeEvent } from '../util/rxjs/fromVsCodeEvent';

--- a/src/server/taskCreators/npmScript.ts
+++ b/src/server/taskCreators/npmScript.ts
@@ -1,4 +1,5 @@
-import { TaskDefinition, workspace } from 'vscode';
+import type { TaskDefinition } from 'vscode';
+import { workspace } from 'vscode';
 import { Utils } from 'vscode-uri';
 import { readConfiguration } from '../../util/getConfiguration';
 import { hasProperty } from '../../util/guards/hasProperty';

--- a/src/server/taskCreators/storybookCli.ts
+++ b/src/server/taskCreators/storybookCli.ts
@@ -1,6 +1,7 @@
 import { firstValueFrom } from 'rxjs';
 import { gte, lt } from 'semver';
-import { Uri, workspace } from 'vscode';
+import type { Uri } from 'vscode';
+import { workspace } from 'vscode';
 import { readConfiguration } from '../../util/getConfiguration';
 import { getInstalledPackageVersion } from '../../util/getInstalledPackageVersion';
 import { isNonEmptyString } from '../../util/guards/isNonEmptyString';

--- a/src/store/StoryStore.ts
+++ b/src/store/StoryStore.ts
@@ -1,9 +1,12 @@
 import pLimit from 'p-limit';
-import { combineLatest, firstValueFrom, Subscription } from 'rxjs';
-import { Disposable, EventEmitter, Uri, workspace } from 'vscode';
+import type { Subscription } from 'rxjs';
+import { combineLatest, firstValueFrom } from 'rxjs';
+import type { Disposable, Uri } from 'vscode';
+import { EventEmitter, workspace } from 'vscode';
 import { Utils } from 'vscode-uri';
 import type { GlobSpecifier } from '../config/GlobSpecifier';
-import { AutodocsConfig, autodocsConfig } from '../config/autodocs';
+import type { AutodocsConfig } from '../config/autodocs';
+import { autodocsConfig } from '../config/autodocs';
 import { storiesGlobs } from '../config/storiesGlobs';
 import {
   initialLoadCompleteContext,
@@ -13,10 +16,8 @@ import { convertGlob } from '../globs/convertGlob';
 import { convertGlobForWorkspace } from '../globs/convertGlobForWorkspace';
 import { logError } from '../log/log';
 import type { parseStoriesFile } from '../parser/parseStoriesFile';
-import {
-  ParsedStoryWithFileUri,
-  parseStoriesFileByUri,
-} from '../parser/parseStoriesFileByUri';
+import type { ParsedStoryWithFileUri } from '../parser/parseStoriesFileByUri';
+import { parseStoriesFileByUri } from '../parser/parseStoriesFileByUri';
 import { StoryExplorerStoryFile } from '../story/StoryExplorerStoryFile';
 import { FileWatcher } from '../util/FileWatcher';
 import { Mailbox } from '../util/Mailbox';

--- a/src/story/StoryExplorerEntry.ts
+++ b/src/story/StoryExplorerEntry.ts
@@ -1,4 +1,5 @@
-import { Range, ViewColumn } from 'vscode';
+import type { ViewColumn } from 'vscode';
+import { Range } from 'vscode';
 import type { Location } from '../types/Location';
 import { createOpenInEditorCommand } from '../util/createOpenCommand';
 import type { IconName } from '../util/getIconPath';

--- a/src/storybook/parseLocalConfigFile.ts
+++ b/src/storybook/parseLocalConfigFile.ts
@@ -1,4 +1,5 @@
-import { ChildProcess, fork, SendHandle } from 'child_process';
+import type { ChildProcess, SendHandle } from 'child_process';
+import { fork } from 'child_process';
 import { resolve } from 'path';
 import {
   defer,

--- a/src/tree/KindTreeNode.ts
+++ b/src/tree/KindTreeNode.ts
@@ -1,7 +1,8 @@
 import type { Uri } from 'vscode';
 import type { StoryExplorerStoryFile } from '../story/StoryExplorerStoryFile';
 import type { IconName } from '../util/getIconPath';
-import { BaseTreeNode, BaseTreeNodeConstuctorParams } from './BaseTreeNode';
+import type { BaseTreeNodeConstuctorParams } from './BaseTreeNode';
+import { BaseTreeNode } from './BaseTreeNode';
 import type { TreeNode } from './TreeNode';
 
 export interface TreeNodeCreationOptions {

--- a/src/tree/StoryTreeDataProvider.test.ts
+++ b/src/tree/StoryTreeDataProvider.test.ts
@@ -1,16 +1,10 @@
 import { basename, extname } from 'path';
 import { describe, expect, it, vitest } from 'vitest';
-import {
-  Command,
-  TextDocumentShowOptions,
-  TreeItemCollapsibleState,
-  Uri,
-} from 'vscode';
+import type { Command, TextDocumentShowOptions, Uri } from 'vscode';
+import { TreeItemCollapsibleState } from 'vscode';
 import { addSerializer } from '../../test/util/addSerializer';
-import {
-  getTreeRoots,
-  TreeItemRepresentation,
-} from '../../test/util/getTreeRoots';
+import type { TreeItemRepresentation } from '../../test/util/getTreeRoots';
+import { getTreeRoots } from '../../test/util/getTreeRoots';
 import { hasProperty } from '../util/guards/hasProperty';
 import { isTruthy } from '../util/guards/isTruthy';
 import { TreeNodeItem } from './TreeNodeItem';

--- a/src/tree/StoryTreeDataProvider.ts
+++ b/src/tree/StoryTreeDataProvider.ts
@@ -1,11 +1,11 @@
 import { firstValueFrom } from 'rxjs';
-import {
+import type {
   Disposable,
-  EventEmitter,
   ExtensionContext,
   TreeDataProvider,
   TreeItem,
 } from 'vscode';
+import { EventEmitter } from 'vscode';
 import { autodocsConfig } from '../config/autodocs';
 import { storiesViewShowItemsWithoutStoriesConfigSuffix } from '../constants/constants';
 import type { StoryStore } from '../store/StoryStore';

--- a/src/tree/TreeNodeItem.ts
+++ b/src/tree/TreeNodeItem.ts
@@ -1,10 +1,5 @@
-import {
-  ExtensionContext,
-  TreeItem,
-  TreeItemCollapsibleState,
-  window,
-  workspace,
-} from 'vscode';
+import type { ExtensionContext } from 'vscode';
+import { TreeItem, TreeItemCollapsibleState, window, workspace } from 'vscode';
 import { createOpenInEditorCommand } from '../util/createOpenCommand';
 import { getIconPath } from '../util/getIconPath';
 import type { TreeNode } from './TreeNode';

--- a/src/tree/TreeViewManager.ts
+++ b/src/tree/TreeViewManager.ts
@@ -1,11 +1,10 @@
-import {
+import type {
   CancellationToken,
-  CancellationTokenSource,
   ExtensionContext,
   TreeView,
   Uri,
-  window,
 } from 'vscode';
+import { CancellationTokenSource, window } from 'vscode';
 import { storyTreeViewId } from '../constants/constants';
 import { logWarn } from '../log/log';
 import type { StoryStore } from '../store/StoryStore';

--- a/src/types/ExtensionManifest.ts
+++ b/src/types/ExtensionManifest.ts
@@ -1,1 +1,3 @@
-export type ExtensionManifest = typeof import('../../package.json');
+import type * as packageJson from '../../package.json';
+
+export type ExtensionManifest = typeof packageJson;

--- a/src/util/FileWatcher.ts
+++ b/src/util/FileWatcher.ts
@@ -1,10 +1,5 @@
-import {
-  Disposable,
-  FileSystemWatcher,
-  GlobPattern,
-  Uri,
-  workspace,
-} from 'vscode';
+import type { Disposable, FileSystemWatcher, GlobPattern, Uri } from 'vscode';
+import { workspace } from 'vscode';
 
 export type WatchListener = (
   uri: Uri,

--- a/src/util/getConfiguration.ts
+++ b/src/util/getConfiguration.ts
@@ -1,4 +1,5 @@
-import { ConfigurationScope, workspace } from 'vscode';
+import type { ConfigurationScope } from 'vscode';
+import { workspace } from 'vscode';
 import { configPrefix } from '../constants/constants';
 import type { ConfigurationSuffix } from '../types/ConfigurationSuffix';
 

--- a/src/util/getFileContent.ts
+++ b/src/util/getFileContent.ts
@@ -1,4 +1,5 @@
-import { Uri, workspace } from 'vscode';
+import type { Uri } from 'vscode';
+import { workspace } from 'vscode';
 
 const getDocumentForUri = (uri: Uri) => {
   return workspace.textDocuments.find(

--- a/src/util/getIconPath.ts
+++ b/src/util/getIconPath.ts
@@ -1,4 +1,5 @@
-import { ColorThemeKind, ExtensionContext, Uri, window } from 'vscode';
+import type { ExtensionContext } from 'vscode';
+import { ColorThemeKind, Uri, window } from 'vscode';
 
 export type IconName = 'bookmark' | 'component' | 'document' | 'folder';
 

--- a/src/util/getRelativePatternForWorkspace.ts
+++ b/src/util/getRelativePatternForWorkspace.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
-import { RelativePattern, Uri, workspace } from 'vscode';
+import type { Uri } from 'vscode';
+import { RelativePattern, workspace } from 'vscode';
 import { Utils } from 'vscode-uri';
 
 export const getRelativePatternForWorkspace = (

--- a/src/util/rxjs/deferAndShare.ts
+++ b/src/util/rxjs/deferAndShare.ts
@@ -1,4 +1,5 @@
-import { defer, ObservableInput, shareReplay } from 'rxjs';
+import type { ObservableInput } from 'rxjs';
+import { defer, shareReplay } from 'rxjs';
 
 export const deferAndShare = <R extends ObservableInput<unknown>>(
   observableFactory: () => R,

--- a/src/util/rxjs/fromEventPatternTyped.ts
+++ b/src/util/rxjs/fromEventPatternTyped.ts
@@ -1,4 +1,5 @@
-import { fromEventPattern, Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { fromEventPattern } from 'rxjs';
 
 interface FromEventPattern {
   <T, TToken>(

--- a/src/util/rxjs/fromVsCodeSetting.ts
+++ b/src/util/rxjs/fromVsCodeSetting.ts
@@ -1,5 +1,6 @@
 import { defer, filter, map, share, startWith } from 'rxjs';
-import { ConfigurationScope, workspace } from 'vscode';
+import type { ConfigurationScope } from 'vscode';
+import { workspace } from 'vscode';
 import type { ConfigurationSuffix } from '../../types/ConfigurationSuffix';
 import { getConfiguration } from '../getConfiguration';
 import { makeFullConfigName } from '../makeFullConfigName';

--- a/src/util/rxjs/watchFile.ts
+++ b/src/util/rxjs/watchFile.ts
@@ -1,5 +1,6 @@
 import { map, merge, Observable, switchMap } from 'rxjs';
-import { FileSystemWatcher, GlobPattern, Uri, workspace } from 'vscode';
+import type { FileSystemWatcher, GlobPattern, Uri } from 'vscode';
+import { workspace } from 'vscode';
 import { isTruthy } from '../guards/isTruthy';
 import { fromVsCodeEvent } from './fromVsCodeEvent';
 

--- a/src/util/tryStat.ts
+++ b/src/util/tryStat.ts
@@ -1,4 +1,5 @@
-import { Uri, workspace } from 'vscode';
+import type { Uri } from 'vscode';
+import { workspace } from 'vscode';
 
 export const tryStat = async (uri: Uri) => {
   try {

--- a/src/webview/StoryWebview.ts
+++ b/src/webview/StoryWebview.ts
@@ -1,12 +1,8 @@
-import {
-  Disposable,
-  ExtensionContext,
-  ViewColumn,
-  WebviewPanel,
-  window,
-} from 'vscode';
+import type { Disposable, ExtensionContext, WebviewPanel } from 'vscode';
+import { ViewColumn, window } from 'vscode';
 import { hostScriptPath } from '../../common/constants';
-import { Message, MessageType } from '../../common/messaging';
+import type { Message } from '../../common/messaging';
+import { MessageType } from '../../common/messaging';
 import { webviewPreviewViewType } from '../constants/constants';
 import { logDebug, logError, logInfo } from '../log/log';
 import type { ProxyManager } from '../proxy/ProxyManager';
@@ -15,7 +11,8 @@ import type { StoryStore } from '../store/StoryStore';
 import type { StoryExplorerEntry } from '../story/StoryExplorerEntry';
 import type { ValueOrPromise } from '../util/ValueOrPromise';
 import { getIconPath } from '../util/getIconPath';
-import { createMessenger, Messenger } from './createMessenger';
+import type { Messenger } from './createMessenger';
+import { createMessenger } from './createMessenger';
 import webviewHtml from './webview.html';
 
 export class StoryWebview {

--- a/src/webview/WebviewManager.ts
+++ b/src/webview/WebviewManager.ts
@@ -1,9 +1,9 @@
-import {
+import type {
   Disposable,
   ExtensionContext,
   WebviewPanelSerializer,
-  window,
 } from 'vscode';
+import { window } from 'vscode';
 import {
   storybookWebviewsOpenContext,
   webviewPreviewViewType,


### PR DESCRIPTION
Use a lint rule instead of the deprecated `importsNotUsedAsValues`.