### PR TITLE
fix: don't hang when config fails to evaluate

### DIFF
--- a/src/storybook/parseLocalConfigFile.ts
+++ b/src/storybook/parseLocalConfigFile.ts
@@ -2,6 +2,7 @@ import type { ChildProcess, SendHandle } from 'child_process';
 import { fork } from 'child_process';
 import { resolve } from 'path';
 import {
+  defaultIfEmpty,
   defer,
   firstValueFrom,
   fromEvent,
@@ -44,6 +45,7 @@ const configParse = (configFilePath: string) => {
           map(([message]) => message),
           takeUntil(fromEvent(childProcess, 'close')),
           timeout({ first: 10000 }),
+          defaultIfEmpty(undefined),
         );
       }),
     ),


### PR DESCRIPTION
If an error is encountered evaluating a config file, the helper process will exit without sending any messages. In this case, proceed as if the config was `undefined` rather than waiting indefinitely.