### PR TITLE
feat: support configuring preview mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Log level to use for logging. Logs are available via the Story Explorer output c
 
 - `debug`: Log debugging information, general operational information, warnings, and errors
 
+### `storyExplorer.preview.mode`
+
+Controls the presentation of the story in the embedded story preview.
+
+### Options
+
+- `canvas`: Displays the story's canvas, without any additional toolbars or Storybook UI.
+
+- `full`: Displays the story within the full Storybook UI.
+
 ### `storyExplorer.server.external.url`
 
 URL of an externally launched and managed Storybook instance, used when [`storyExplorer.server.internal.enabled`](#storyexplorerserverinternalenabled) is disabled. Defaults to `http://localhost:6006`.

--- a/common/messaging.ts
+++ b/common/messaging.ts
@@ -78,6 +78,10 @@ export interface LoadStoryMessage {
    * server.
    */
   isInternalServer: boolean;
+  /**
+   * The type of story preview to load.
+   */
+  previewMode: 'canvas' | 'full';
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -479,6 +479,19 @@
           "markdownDescription": "Controls whether to offer suggestions for story IDs when using `<Story id=\"...\" />` in MDX files. Suggestions are based on the IDs of other stories in the project.",
           "type": "boolean",
           "default": true
+        },
+        "storyExplorer.preview.mode": {
+          "scope": "window",
+          "markdownDescription": "Controls the presentation of the story in the embedded story preview.",
+          "default": "canvas",
+          "enum": [
+            "canvas",
+            "full"
+          ],
+          "markdownEnumDescriptions": [
+            "Displays the story's canvas, without any additional toolbars or Storybook UI.",
+            "Displays the story within the full Storybook UI."
+          ]
         }
       }
     },

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -63,6 +63,7 @@ export const storiesViewShowItemsWithoutStoriesConfigSuffix =
 export const storybookConfigDirConfigSuffix = 'storybookConfigDir';
 export const suggestStoryIdConfigSuffix = 'suggestStoryId';
 export const suggestTitleConfigSuffix = 'suggestTitle';
+export const previewModeConfigSuffix = 'preview.mode';
 
 export const serverExternalUrlConfig = makeFullConfigName(
   serverExternalUrlConfigSuffix,

--- a/src/webview/StoryWebview.ts
+++ b/src/webview/StoryWebview.ts
@@ -10,6 +10,7 @@ import type { ServerManager } from '../server/ServerManager';
 import type { StoryStore } from '../store/StoryStore';
 import type { StoryExplorerEntry } from '../story/StoryExplorerEntry';
 import type { ValueOrPromise } from '../util/ValueOrPromise';
+import { readConfiguration } from '../util/getConfiguration';
 import { getIconPath } from '../util/getIconPath';
 import type { Messenger } from './createMessenger';
 import { createMessenger } from './createMessenger';
@@ -199,11 +200,16 @@ export class StoryWebview {
   }
 
   private finishLoading(storybookUrl: string, proxyPort: number) {
+    const previewMode = readConfiguration<'canvas' | 'full'>(
+      'preview.mode',
+      'canvas',
+    );
     return this.messenger.send({
       type: MessageType.LoadStory,
       port: proxyPort,
       storybookUrl,
       isInternalServer: this.serverManager.isInternalServerEnabled(),
+      previewMode,
     });
   }
 

--- a/webview/entry-host.ts
+++ b/webview/entry-host.ts
@@ -1,4 +1,5 @@
-import { Message, MessageType } from '../common/messaging';
+import type { Message } from '../common/messaging';
+import { MessageType } from '../common/messaging';
 import { createIframeElement } from './createIframeElement';
 import errorHtml from './error.html';
 import { listen } from './listen';
@@ -27,14 +28,14 @@ const handleExtensionHostMessage = (hostMessage: Message): void => {
       break;
     }
     case MessageType.LoadStory: {
-      const { port, storybookUrl } = hostMessage;
+      const { port, storybookUrl, previewMode } = hostMessage;
       const { storyId, storyType } = storyInfo;
 
       const iframeSrc = `http://localhost:${Number(
         port,
       )}/__vscode_story_explorer_iframe#storyId=${encodeURIComponent(
         storyId,
-      )}&storyType=${encodeURIComponent(storyType)}`;
+      )}&storyType=${encodeURIComponent(storyType)}&mode=${previewMode}`;
 
       const iframeUrl = new URL(iframeSrc);
       const innerIframeOrigin = iframeUrl.origin;

--- a/webview/entry-story.ts
+++ b/webview/entry-story.ts
@@ -1,5 +1,6 @@
 import { ERR_BAD_GATEWAY } from '../common/constants';
-import { Message, MessageType } from '../common/messaging';
+import type { Message } from '../common/messaging';
+import { MessageType } from '../common/messaging';
 import { createIframeElement } from './createIframeElement';
 
 const storybookBgColor = 'rgb(246, 249, 252)';
@@ -20,7 +21,39 @@ const handleIframeWindowError = (e: ErrorEvent): void => {
   e.stopImmediatePropagation();
 };
 
-const createIframe = (storyId: string, storyType: string) => {
+const getStoryUrl = (
+  storyId: string,
+  storyType: string,
+  mode: string | null,
+) => {
+  const encodedStoryId = encodeURIComponent(storyId);
+  const encodedStoryType = encodeURIComponent(storyType);
+
+  switch (mode) {
+    case 'full':
+      return `/?path=/${encodedStoryType}/${encodedStoryId}&nav=0&panel=bottom&singleStory=true`;
+    case 'canvas':
+    default: {
+      // For docs, we (sometimes) rely on storybook figuring out the full ID for us,
+      // which requires the full story store to be loaded. (Investigate whether this
+      // is also needed to support <Story /> elements that reference other stories,
+      // in which case we really can't use `singleStory` for docs.)
+      const useSingleStory = storyType === 'story';
+
+      return `/iframe.html?id=${encodeURIComponent(
+        storyId,
+      )}&viewMode=${encodeURIComponent(storyType)}${
+        useSingleStory ? '&singleStory=true' : ''
+      }`;
+    }
+  }
+};
+
+const createIframe = (
+  storyId: string,
+  storyType: string,
+  mode: string | null,
+) => {
   const iframe = createIframeElement();
 
   const handleIframeLoad = () => {
@@ -35,19 +68,7 @@ const createIframe = (storyId: string, storyType: string) => {
 
   iframe.addEventListener('load', handleIframeLoad);
 
-  // For docs, we (sometimes) rely on storybook figuring out the full ID for us,
-  // which requires the full story store to be loaded. (Investigate whether this
-  // is also needed to support <Story /> elements that reference other stories,
-  // in which case we really can't use `singleStory` for docs.)
-  const useSingleStory = storyType === 'story';
-
-  const src = `/iframe.html?id=${encodeURIComponent(
-    storyId,
-  )}&viewMode=${encodeURIComponent(storyType)}${
-    useSingleStory ? '&singleStory=true' : ''
-  }`;
-
-  iframe.src = src;
+  iframe.src = getStoryUrl(storyId, storyType, mode);
 
   return iframe;
 };
@@ -56,8 +77,9 @@ const handleLoad = () => {
   const params = new URLSearchParams(window.location.hash.slice(1));
   const storyId = params.get('storyId');
   const storyType = params.get('storyType');
+  const mode = params.get('mode');
 
-  const sbIframe = createIframe(storyId ?? '', storyType ?? 'story');
+  const sbIframe = createIframe(storyId ?? '', storyType ?? 'story', mode);
 
   document.body.style.backgroundColor = storybookBgColor;
   document.body.appendChild(sbIframe);


### PR DESCRIPTION
Add a configuration option to specify the embedded preview mode:
- `canvas`: displays the story's canvas, without any additional toolbars or Storybook UI (default and existing behavior)
- `full`: displays the story within the full Storybook UI