### PR TITLE
feat: add option to prefer external server if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Controls the presentation of the story in the embedded story preview.
 
 ### `storyExplorer.server.external.url`
 
-URL of an externally launched and managed Storybook instance, used when [`storyExplorer.server.internal.enabled`](#storyexplorerserverinternalenabled) is disabled. Defaults to `http://localhost:6006`.
+URL of an externally launched and managed Storybook instance, used when [`storyExplorer.server.internal.preferExternal`](#storyexplorerserverinternalpreferexternal) is enabled or [`storyExplorer.server.internal.enabled`](#storyexplorerserverinternalenabled) is disabled. Defaults to `http://localhost:6006`.
 
 ### `storyExplorer.server.internal.behavior`
 
@@ -120,6 +120,10 @@ Optional path to the directory containing the `package.json` file with the npm s
 ### `storyExplorer.server.internal.npm.script`
 
 Name of the npm script to use to launch the Storybook development server. Defaults to `storybook`. Only used when [`storyExplorer.server.internal.launchStrategy`](#storyexplorerserverinternallaunchstrategy) is set to `npm` or `detect`.
+
+### `storyExplorer.server.internal.preferExternal` (experimental)
+
+Controls whether to check for a running external Storybook server before launching an internal server. If the external server is reachable, it will be used instead. You can specify the external URL to check by setting [`storyExplorer.server.external.url`](#storyexplorerserverexternalurl)
 
 ### `storyExplorer.server.internal.startStorybook.args`
 

--- a/package.json
+++ b/package.json
@@ -429,6 +429,15 @@
           "default": true,
           "type": "boolean"
         },
+        "storyExplorer.server.internal.preferExternal": {
+          "scope": "window",
+          "markdownDescription": "Controls whether to check for a running external Storybook server before launching an internal server. If the external server is reachable, it will be used instead. You can specify the external URL to check by setting `#storyExplorer.server.external.url#`",
+          "default": false,
+          "type": "boolean",
+          "tags": [
+            "experimental"
+          ]
+        },
         "storyExplorer.server.internal.behavior": {
           "scope": "window",
           "markdownDescription": "Controls when to automatically start a Storybook development server. This setting only applies when `#storyExplorer.server.internal.enabled#` is enabled.",
@@ -444,7 +453,7 @@
         },
         "storyExplorer.server.external.url": {
           "scope": "window",
-          "markdownDescription": "URL of an externally launched and managed Storybook instance, used when `#storyExplorer.server.internal.enabled#` is disabled. Defaults to `http://localhost:6006`.",
+          "markdownDescription": "URL of an externally launched and managed Storybook instance, used when `#storyExplorer.server.internal.preferExternal#` is enabled or `#storyExplorer.server.internal.enabled#` is disabled. Defaults to `http://localhost:6006`.",
           "type": "string",
           "examples": [
             "http://localhost:6006"

--- a/scripts/generateSettingsReadmeMarkdown.ts
+++ b/scripts/generateSettingsReadmeMarkdown.ts
@@ -24,7 +24,13 @@ const parseMarkdown = (markdown: string) => {
 const output = Object.entries(settings)
   .sort(([a], [b]) => a.localeCompare(b))
   .map(([key, value]) => {
-    const paragraphs = [`### \`${key}\``];
+    const tags = 'tags' in value ? value.tags : [];
+
+    const annotations = [
+      tags.includes('experimental') ? '(experimental)' : undefined,
+    ].filter(Boolean);
+
+    const paragraphs = [[`### \`${key}\``, ...annotations].join(' ')];
 
     if (
       'markdownDeprecationMessage' in value &&

--- a/src/commands/openPreviewInBrowser.ts
+++ b/src/commands/openPreviewInBrowser.ts
@@ -34,13 +34,13 @@ export const openPreviewInBrowser =
       return;
     }
 
-    const host = await serverManager.ensureServerHealthy();
-    if (!host) {
+    const { url } = await serverManager.ensureServerHealthy();
+    if (!url) {
       return;
     }
 
     const storyId = story.id;
-    const baseUri = Uri.parse(host, true);
+    const baseUri = Uri.parse(url, true);
     const uriToOpen = storyId
       ? baseUri.with({
           query: `path=/${story.type}/${encodeURIComponent(storyId)}`,

--- a/src/commands/openStorybookInBrowser.ts
+++ b/src/commands/openStorybookInBrowser.ts
@@ -5,12 +5,12 @@ import type { ServerManager } from '../server/ServerManager';
 export const openStorybookInBrowser =
   (serverManager: ServerManager) => async () => {
     try {
-      const host = await serverManager.ensureServerHealthy();
-      if (!host) {
+      const { url } = await serverManager.ensureServerHealthy();
+      if (!url) {
         return;
       }
 
-      const uriToOpen = Uri.parse(host, true);
+      const uriToOpen = Uri.parse(url, true);
       await env.openExternal(uriToOpen);
     } catch (e) {
       logError('Failed to launch storybook in browser', e);

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -53,6 +53,8 @@ export const serverInternalBehaviorConfigSuffix = 'server.internal.behavior';
 export const serverInternalCommandLineArgsConfigSuffix =
   'server.internal.commandLineArgs';
 export const serverInternalEnabledConfigSuffix = 'server.internal.enabled';
+export const serverInternalPreferExternalConfigSuffix =
+  'server.internal.preferExternal';
 export const serverInternalEnvironmentVariablesConfigSuffix =
   'server.internal.environmentVariables';
 export const serverInternalStorybookBinaryPathConfigSuffix =

--- a/src/proxy/ProxyServer.ts
+++ b/src/proxy/ProxyServer.ts
@@ -75,8 +75,8 @@ export class ProxyServer {
       } else {
         Promise.resolve(this.getProxyTarget())
           .then((target) => {
-            if (target) {
-              proxy.web(req, res, { target }, (e) => {
+            if (target.url) {
+              proxy.web(req, res, { target: target.url }, (e) => {
                 logWarn('Failed to proxy request', e, target);
                 res.writeHead(502);
                 res.write(ERR_BAD_GATEWAY);

--- a/src/server/StorybookServer.ts
+++ b/src/server/StorybookServer.ts
@@ -97,7 +97,7 @@ export class StorybookServer {
             async () => {
               try {
                 logDebug(`Sending request to ${url}`);
-                return await fetch(url, token);
+                return await fetch(url, { token });
               } catch (e: unknown) {
                 if (e instanceof TimeoutError) {
                   logDebug('Caught timeout error');

--- a/src/server/fetch.ts
+++ b/src/server/fetch.ts
@@ -5,7 +5,16 @@ import { CancellationError } from 'vscode';
 
 export class TimeoutError extends Error {}
 
-export const fetch = (url: string, token: CancellationToken) => {
+export const fetch = (
+  url: string,
+  {
+    token,
+    timeout,
+  }: {
+    token?: CancellationToken;
+    timeout?: number;
+  },
+) => {
   return new Promise<IncomingMessage>((resolve, reject) => {
     const cleanup = () => {
       tokenListener?.dispose();
@@ -15,7 +24,7 @@ export const fetch = (url: string, token: CancellationToken) => {
       }
     };
 
-    const req = request(url)
+    const req = request(url, { timeout })
       .once('response', (res) => {
         cleanup();
         resolve(res);
@@ -35,7 +44,7 @@ export const fetch = (url: string, token: CancellationToken) => {
 
     req.end();
 
-    let tokenListener: Disposable | undefined = token.onCancellationRequested(
+    let tokenListener: Disposable | undefined = token?.onCancellationRequested(
       () => {
         cleanup();
         reject(new CancellationError());


### PR DESCRIPTION
Add a new option, `storyExplorer.server.internal.preferExternal`, that checks to see if there is an external server already running at a configured URL before launching an internal server. If it is reachable, the external server is used instead.